### PR TITLE
Update repo for recent pixi, recent mujoco and use CUDA 12

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1,412 +1,648 @@
-metadata:
-  content_hash:
-    linux-64: 6118fa318ffd3bc107a29f1ac77ce1e35ff5d11d8a27db69d43362962a054b02
-  channels:
-  - url: https://conda.anaconda.org/conda-forge/
-    used_env_vars: []
-  - url: https://conda.anaconda.org/nvidia/
-    used_env_vars: []
-  platforms:
-  - linux-64
-  sources: []
-  time_metadata: null
-  git_metadata: null
-  inputs_metadata: null
-  custom_metadata: null
-package:
-- platform: linux-64
+version: 4
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py310hd41b1e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.4.99-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.4.99-hcdd1206_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.4.99-h8a487aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.9.7.29-h092f7fd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py310hc6cd4ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dm-tree-0.1.8-py310ha8c1f0e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-4.4.0-h6987444_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.49.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.1-py310h1b8f574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gym-0.26.1-py310hfdc917e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.4.23-cuda120py310h3cc97ca_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.0.4-hd9d6309_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.4.2.65-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.2.0.44-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.5.119-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.6.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.6.0.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.3.0.142-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmujoco-3.1.3-hfbbffa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.4.99-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.11.0-h9c3ff4c_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lodepng-20220109-h924138e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py310h62c0568_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.3.2-py310hcc13569_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.7-py310hd41b1e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mujoco-3.1.3-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mujoco-python-3.1.3-py310hb9d608c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mujoco-samples-3.1.3-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mujoco-simulate-3.1.3-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.20.5.1-h3a97aeb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.2.0-py310h01dd4db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py310ha8c1f0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyglfw-2.7.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytinyrenderer-0.0.13-py310he0c9aae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py310h795f18f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h4bd325d_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.18.0-py310hcb5633a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.12.0-py310hb13e2d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.0.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tensorstore-0.1.56-py310h3c30d94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!161.3030-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/brax-0.10.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/chex-0.1.85-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextlib2-21.6.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-12.4.99-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.4.99-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-12.4.99-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.4.99-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.4.99-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.4-h3060b56_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dm-env-1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/etils-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-cors-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flax-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gym-notices-0.0.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyhd33586a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.4.25-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxopt-0.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mediapy-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ml-collections-0.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mujoco-mjx-3.1.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opt-einsum-3.3.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.3.0-pyhc1e730c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/optax-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-he073ed8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tensorboardx-2.6.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+packages:
+- kind: conda
   name: _libgcc_mutex
   version: '0.1'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   build: conda_forge
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
   license: None
   size: 2562
   timestamp: 1578324546067
-- platform: linux-64
+- kind: conda
   name: _openmp_mutex
   version: '4.5'
-  category: main
-  manager: conda
-  dependencies:
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - libgomp >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  build: 2_gnu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 16
   constrains:
   - openmp_impl 9999
   license: BSD-3-Clause
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- platform: linux-64
+- kind: conda
+  name: _sysroot_linux-64_curr_repodata_hack
+  version: '3'
+  build: h69a702a_14
+  build_number: 14
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_14.conda
+  sha256: 0dbeaddc3d5134b5336c52ac05642533b8d1ba2e1316aa92981f4cf5b5388de0
+  md5: 38d211c448a67f12fe693fe25df4da23
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 21169
+  timestamp: 1708000801681
+- kind: conda
   name: absl-py
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2361c56617987bb6623dcbf8bab5cdc4
-    sha256: 99e2a54d079d91909d6d12d2336d792fd2ab666620d2ac761cd09d0e552dd44d
+  version: 2.1.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
+  sha256: 6c84575fe0c3a860c7b6a52cb36dc548c838503c8da0f950a63a64c29b443937
+  md5: 035d1d58677c13ec93122d9eb6b8803b
+  depends:
+  - python >=3.7
   license: Apache-2.0
   license_family: Apache
-  noarch: python
-  size: 105179
-  timestamp: 1695154668784
-- platform: linux-64
+  size: 107266
+  timestamp: 1705494755555
+- kind: conda
   name: anyio
-  version: 4.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - exceptiongroup
+  version: 4.3.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+  sha256: 86aca4a31c09f9b4dbdb332cd9a6a7dbab62ca734d3f832651c0ab59c6a7f52e
+  md5: ac95aa8ed65adfdde51132595c79aade
+  depends:
+  - exceptiongroup >=1.0.2
   - idna >=2.8
   - python >=3.8
   - sniffio >=1.1
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3c4e99d3ae4ec033d4dd99fb5220e540
-    sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - typing_extensions >=4.1
   constrains:
-  - trio >=0.22
+  - trio >=0.23
+  - uvloop >=0.17
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 98958
-  timestamp: 1693488730301
-- platform: linux-64
+  size: 102331
+  timestamp: 1708355504396
+- kind: conda
   name: aom
-  version: 3.6.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.8.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
+  sha256: 49b1352e2b9710b7b5400c0f2a86c0bb805091ecfc6c84d3dbf064effe33bfbf
+  md5: 625e1fed28a5139aed71b3a76117ef84
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.6.1-h59595ed_0.conda
-  hash:
-    md5: 8457db6d1175ee86c8e077f6ac60ff55
-    sha256: 006d10fe845374e71fb15a6c1f58ae4b3efef69be02b0992265abfb5c4c2e026
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-2-Clause
   license_family: BSD
-  size: 2678249
-  timestamp: 1694225960207
-- platform: linux-64
+  size: 2696998
+  timestamp: 1710388229587
+- kind: conda
   name: argon2-cffi
   version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
   - argon2-cffi-bindings
   - python >=3.7
   - typing-extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - argon2_cffi ==999
   license: MIT
   license_family: MIT
-  noarch: python
   size: 18602
   timestamp: 1692818472638
-- platform: linux-64
+- kind: conda
   name: argon2-cffi-bindings
   version: 21.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py310h2372a71_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+  sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
+  md5: 68ee85860502d53c8cbfa0e4cef0f6cb
+  depends:
   - cffi >=1.0.1
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
-  hash:
-    md5: 68ee85860502d53c8cbfa0e4cef0f6cb
-    sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
-  build: py310h2372a71_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
   license: MIT
   license_family: MIT
   size: 34384
   timestamp: 1695386695142
-- platform: linux-64
+- kind: conda
   name: arrow
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
   - python >=3.8
   - python-dateutil >=2.7.0
   - types-python-dateutil >=2.8.10
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 100096
   timestamp: 1696129131844
-- platform: linux-64
+- kind: conda
   name: asttokens
   version: 2.4.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
   - python >=3.5
   - six >=1.12.0
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 28922
   timestamp: 1698341257884
-- platform: linux-64
+- kind: conda
   name: async-lru
   version: 2.0.4
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
   - python >=3.8
   - typing_extensions >=4.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15342
   timestamp: 1690563152778
-- platform: linux-64
+- kind: conda
   name: attrs
-  version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 23.2.0
+  build: pyh71513ae_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+  sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+  md5: 5e4c0743c70186509d1412e03c2d8dfa
+  depends:
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  build: pyh71513ae_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 55022
-  timestamp: 1683424195402
-- platform: linux-64
+  size: 54582
+  timestamp: 1704011393776
+- kind: conda
   name: babel
-  version: 2.13.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.14.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
+  sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
+  md5: 9669586875baeced8fc30c0826c3270e
+  depends:
   - python >=3.7
   - pytz
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ccff479c246692468f604df9c85ef26
-    sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 6948100
-  timestamp: 1698174685067
-- platform: linux-64
-  name: backports
-  version: '1.0'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
-  hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  build: pyhd8ed1ab_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 5950
-  timestamp: 1669158729416
-- platform: linux-64
-  name: backports.functools_lru_cache
-  version: 1.6.5
-  category: main
-  manager: conda
-  dependencies:
-  - backports
-  - python >=3.6
-  - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6b1b907661838a75d067a22f87996b2e
-    sha256: 7027bb689dd4ca4a08e3b25805de9d04239be6b31125993558f21f102a9d2700
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11519
-  timestamp: 1687772319931
-- platform: linux-64
+  size: 7609750
+  timestamp: 1702422720584
+- kind: conda
   name: beautifulsoup4
-  version: 4.12.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.12.3
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  md5: 332493000404d8411859539a5a630865
+  depends:
   - python >=3.6
   - soupsieve >=1.2
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
-  hash:
-    md5: a362ff7d976217f8fa78c0f1c4f59717
-    sha256: 52d3e6bcd442537e22699cd227d8fdcfd54b708eeb8ee5b4c671a6a9b9cd74da
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 115011
-  timestamp: 1680888259061
-- platform: linux-64
+  size: 118200
+  timestamp: 1705564819537
+- kind: conda
+  name: binutils_impl_linux-64
+  version: '2.40'
+  build: hf600244_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+  sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
+  md5: 33084421a8c0af6aef1b439707f7662a
+  depends:
+  - ld_impl_linux-64 2.40 h41732ed_0
+  - sysroot_linux-64
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5414922
+  timestamp: 1674833958334
+- kind: conda
+  name: binutils_linux-64
+  version: '2.40'
+  build: hdade7a5_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
+  sha256: d114b825acef51c1d065ca0a17f97e0e856c48765aecf2f8f164935635013dd2
+  md5: 2d9a60578bc28469d9aeef9aea5520c3
+  depends:
+  - binutils_impl_linux-64 2.40.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28868
+  timestamp: 1710259805994
+- kind: conda
   name: bleach
   version: 6.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+  depends:
   - packaging
   - python >=3.6
   - setuptools
   - six >=1.9.0
   - webencodings
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 131220
   timestamp: 1696630354218
-- platform: linux-64
+- kind: conda
   name: blinker
   version: 1.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 550da20b2c2e38be9cc44bb819fda5d5
-    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
+  md5: 550da20b2c2e38be9cc44bb819fda5d5
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
   size: 17886
   timestamp: 1698890303249
-- platform: linux-64
+- kind: conda
   name: blosc
   version: 1.21.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h0f2a231_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+  sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+  md5: 009521b7ed97cca25f8f997f9e745976
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
-  hash:
-    md5: 009521b7ed97cca25f8f997f9e745976
-    sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
-  build: h0f2a231_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   size: 48692
   timestamp: 1693657088079
-- platform: linux-64
+- kind: conda
   name: brax
-  version: 0.9.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.10.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/brax-0.10.3-pyhd8ed1ab_0.conda
+  sha256: ebef000f5541f99dc4423f2263917dff7b080b8e9c63c6cfc0f97269d1579349
+  md5: 2e0359e08bc6768811c63cbbc7342b2a
+  depends:
   - absl-py
   - dataclasses
   - dm-env
@@ -422,6 +658,7 @@ package:
   - jaxopt
   - jinja2
   - ml-collections
+  - mujoco-mjx
   - mujoco-python
   - numpy
   - optax
@@ -433,282 +670,194 @@ package:
   - tensorboardx
   - trimesh
   - typing-extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/brax-0.9.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: bf76bf69b999eb7f8fe59503dd6c3a07
-    sha256: ad8ebf60cd7fcf582b6729d5411241fb91212a859d56b6bf1c50803d335aac0f
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
-  noarch: python
-  size: 4364230
-  timestamp: 1699535574341
-- platform: linux-64
+  license_family: APACHE
+  size: 589076
+  timestamp: 1710370422586
+- kind: conda
   name: brotli
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+  sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+  md5: f27a24d46e3ea7b70a1f98e50c62508f
+  depends:
   - brotli-bin 1.1.0 hd590300_1
   - libbrotlidec 1.1.0 hd590300_1
   - libbrotlienc 1.1.0 hd590300_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
-  hash:
-    md5: f27a24d46e3ea7b70a1f98e50c62508f
-    sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
   size: 19383
   timestamp: 1695990069230
-- platform: linux-64
+- kind: conda
   name: brotli-bin
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+  sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+  md5: 39f910d205726805a958da408ca194ba
+  depends:
   - libbrotlidec 1.1.0 hd590300_1
   - libbrotlienc 1.1.0 hd590300_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
-  hash:
-    md5: 39f910d205726805a958da408ca194ba
-    sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
   size: 18980
   timestamp: 1695990054140
-- platform: linux-64
+- kind: conda
   name: brotli-python
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py310hc6cd4ac_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+  sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
+  md5: 1f95722c94f00b69af69a066c7433714
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
-  hash:
-    md5: 1f95722c94f00b69af69a066c7433714
-    sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
-  build: py310hc6cd4ac_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   constrains:
   - libbrotlicommon 1.1.0 hd590300_1
   license: MIT
   license_family: MIT
   size: 349397
   timestamp: 1695990295884
-- platform: linux-64
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-  hash:
-    md5: 69b8b6202a07720f448be700e300ccf4
-    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
   build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
   build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+  md5: 69b8b6202a07720f448be700e300ccf4
+  depends:
+  - libgcc-ng >=12
   license: bzip2-1.0.6
   license_family: BSD
   size: 254228
   timestamp: 1699279927352
-- platform: linux-64
+- kind: conda
   name: c-ares
-  version: 1.21.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.21.0-hd590300_0.conda
-  hash:
-    md5: c06fa0440048270817b9e3142cc661bf
-    sha256: dfe0e81d5462fced79fd0f99edeec94c9b27268cb04238638180981af2f889f1
+  version: 1.27.0
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.27.0-hd590300_0.conda
+  sha256: 2a5866b19d28cb963fab291a62ff1c884291b9d6f59de14643e52f103e255749
+  md5: f6afff0e9ee08d2f1b897881a4f38cdb
+  depends:
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
-  size: 121680
-  timestamp: 1698936210587
-- platform: linux-64
+  size: 163578
+  timestamp: 1708684786032
+- kind: conda
   name: ca-certificates
-  version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
-  hash:
-    md5: a73ecd2988327ad4c8f2c331482917f2
-    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  version: 2024.2.2
   build: hbcca054_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+  sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+  md5: 2f4327a1cbe7f022401b236e915a5fef
   license: ISC
-  size: 149515
-  timestamp: 1690026108541
-- platform: linux-64
+  size: 155432
+  timestamp: 1706843687645
+- kind: conda
   name: cached-property
   version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - cached_property >=1.5.2,<1.5.3.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
   build: hd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 4134
   timestamp: 1615209571450
-- platform: linux-64
+- kind: conda
   name: cached_property
   version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
   build: pyha770c72_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 11065
   timestamp: 1615209567874
-- platform: linux-64
-  name: cairo
-  version: 1.18.0
-  category: main
-  manager: conda
-  dependencies:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-  hash:
-    md5: f907bb958910dc404647326ca80c263e
-    sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  build: h3faef2a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-only or MPL-1.1
-  size: 982351
-  timestamp: 1697028423052
-- platform: linux-64
+- kind: conda
   name: certifi
-  version: 2023.7.22
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
-    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
+  version: 2024.2.2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
+  subdir: noarch
   noarch: python
-  size: 153791
-  timestamp: 1690024617757
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+  sha256: f1faca020f988696e6b6ee47c82524c7806380b37cfdd1def32f92c326caca54
+  md5: 0876280e409658fc6f9e75d035960333
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 160559
+  timestamp: 1707022289175
+- kind: conda
   name: cffi
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py310h2fee648_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+  sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
+  md5: 45846a970e71ac98fd327da5d40a0a2c
+  depends:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - pycparser
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
-  hash:
-    md5: 45846a970e71ac98fd327da5d40a0a2c
-    sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
-  build: py310h2fee648_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 241339
   timestamp: 1696001848492
-- platform: linux-64
+- kind: conda
   name: charset-normalizer
   version: 3.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
   license: MIT
   license_family: MIT
-  noarch: python
   size: 46597
   timestamp: 1698833765762
-- platform: linux-64
+- kind: conda
   name: chex
-  version: 0.1.84
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.1.85
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/chex-0.1.85-pyhd8ed1ab_0.conda
+  sha256: f065542a483b9cb736a370b7f3ceda9b84234b56b7ebf90159c3b6f1500a2951
+  md5: 2189d1de55e74c75f3e45b4c3f4a5ef2
+  depends:
   - absl-py >=0.9.0
   - jax >=0.4.16
   - jaxlib >=0.1.37
@@ -716,522 +865,691 @@ package:
   - python >=3.9
   - toolz >=0.9.0
   - typing-extensions >=4.2.0
-  url: https://conda.anaconda.org/conda-forge/noarch/chex-0.1.84-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00f631c2cd9c7c9673fdf923d35d37ad
-    sha256: 87eb3f3fc35dbd8cbc8505594a816d5509b829f2b5f594e86bdccbb6cdd66dcb
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 76076
-  timestamp: 1697807141389
-- platform: linux-64
+  size: 76406
+  timestamp: 1700682764074
+- kind: conda
   name: click
   version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
+  build: unix_pyh707e725_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
   - __unix
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  build: unix_pyh707e725_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 84437
   timestamp: 1692311973840
-- platform: linux-64
+- kind: conda
   name: cloudpickle
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  md5: 753d29fe41bb881e4b9c004f0abf973f
+  depends:
+  - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 24746
   timestamp: 1697464875382
-- platform: linux-64
+- kind: conda
   name: comm
-  version: 0.1.4
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.2.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
   - python >=3.6
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: c8eaca39e2b6abae1fc96acc929ae939
-    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 11682
-  timestamp: 1691045097208
-- platform: linux-64
+  size: 12134
+  timestamp: 1710320435158
+- kind: conda
   name: contextlib2
   version: 21.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/contextlib2-21.6.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5b26a831440be04c39531a8ce20f5d71
-    sha256: 7762dc5b54c4e3e66f3c1d425ac2c6d1cff651e8fd4ab8d4d5ddfa883028ffaa
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/contextlib2-21.6.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7762dc5b54c4e3e66f3c1d425ac2c6d1cff651e8fd4ab8d4d5ddfa883028ffaa
+  md5: 5b26a831440be04c39531a8ce20f5d71
+  depends:
+  - python >=3.6
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 16367
   timestamp: 1624848715744
-- platform: linux-64
+- kind: conda
   name: contourpy
   version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py310hd41b1e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py310hd41b1e2_0.conda
+  sha256: 73dd7868bfd98fa9e4d2cc524687b5c5c8f9d427d4e521875aacfe152eae4715
+  md5: 85d2aaa7af046528d339da1e813c3a9f
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.20,<2
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py310hd41b1e2_0.conda
-  hash:
-    md5: 85d2aaa7af046528d339da1e813c3a9f
-    sha256: 73dd7868bfd98fa9e4d2cc524687b5c5c8f9d427d4e521875aacfe152eae4715
-  build: py310hd41b1e2_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   size: 238877
   timestamp: 1699041552962
-- platform: linux-64
-  name: cuda-nvcc
-  version: 11.8.89
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-11.8.89-0.tar.bz2
-  hash:
-    md5: 33f9af6dac16b94a7dc1111a18fd19bf
-    sha256: 23ee509485627c7e402d0d6c4567e02641430a37581f1da0a4d5478dd5cecc0e
-  build: '0'
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  size: 53254905
-  timestamp: 1663787076437
-- platform: linux-64
-  name: cuda-version
-  version: '11.8'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/cuda-version-11.8-h70ddcb2_2.conda
-  hash:
-    md5: 601900ec9ff06f62f76a247148e52c04
-    sha256: cb8a81465d5fa1b27e14981b7e1a9be4fc90945261a7459427e7bfb42129e26c
-  build: h70ddcb2_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  constrains:
-  - cudatoolkit 11.8|11.8.*
-  - __cuda >=11
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
+- kind: conda
+  name: cuda-cccl_linux-64
+  version: 12.4.99
+  build: ha770c72_0
+  subdir: noarch
   noarch: generic
-  size: 20911
-  timestamp: 1683165527717
-- platform: linux-64
-  name: cudatoolkit
-  version: 11.8.0
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-12.4.99-ha770c72_0.conda
+  sha256: a508e5bf9f878920540d3c69b1296538b0f31f57382ea4775001d055e4558900
+  md5: d980ee9295f1a23a414868c1074faacf
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 1306648
+  timestamp: 1709669925199
+- kind: conda
+  name: cuda-crt-dev_linux-64
+  version: 12.4.99
+  build: ha770c72_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.4.99-ha770c72_0.conda
+  sha256: 809197dc52b57a13410a4e43e40e4d2e9502302e386d69ad11c55e9034da3f03
+  md5: f3bda40aafe397a6a1abda11c9db0078
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 88260
+  timestamp: 1709707434840
+- kind: conda
+  name: cuda-crt-tools
+  version: 12.4.99
+  build: ha770c72_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.4.99-ha770c72_0.conda
+  sha256: dd46a829729adca93ad8d54fdf9efe3ca9be617ff2238c3baf03d1ac6dbe9652
+  md5: 9d3a57e31761b2d751ba7fe87f80df38
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 26068
+  timestamp: 1709707457304
+- kind: conda
+  name: cuda-cudart
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.4.99-hd3aeb46_0.conda
+  sha256: a98f120b8578e9d5dc6997e49caca972147d22e69760c432ca24b1f16208e5b0
+  md5: 4d229c1bd27b08f176d35dd2b6fa3e43
+  depends:
   - __glibc >=2.17,<3.0.a0
+  - cuda-cudart_linux-64 12.4.99 h59595ed_0
+  - cuda-version >=12.4,<12.5.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudatoolkit-11.8.0-h4ba93d1_12.conda
-  hash:
-    md5: 59a4d915d3406b3d11298e927db71ae0
-    sha256: fec3919316eef16368c2ab013c77beaf3f40b2f6a2f2bd5227bbd4ab7fa8dd8c
-  build: h4ba93d1_12
-  arch: x86_64
-  subdir: linux-64
-  build_number: 12
-  constrains:
-  - __cuda >=11
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 715999720
-  timestamp: 1690600035537
-- platform: linux-64
-  name: cudnn
-  version: 8.8.0.121
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17
+  size: 22453
+  timestamp: 1709678870024
+- kind: conda
+  name: cuda-cudart-dev
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-12.4.99-hd3aeb46_0.conda
+  sha256: 9ff4e9bc60578d35c33e25c285823ed45c7a1902e70519e8cab41293aec8d955
+  md5: 5c2ac9e42a6be993b9525d95f4fda39d
+  depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=11.0,<12.0a0
-  - cudatoolkit 11.*
+  - cuda-cudart 12.4.99 hd3aeb46_0
+  - cuda-cudart-dev_linux-64 12.4.99 h59595ed_0
+  - cuda-cudart-static 12.4.99 hd3aeb46_0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 22925
+  timestamp: 1709678968958
+- kind: conda
+  name: cuda-cudart-dev_linux-64
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-12.4.99-h59595ed_0.conda
+  sha256: e49169062c60344ff54f2a1f4305292a449e3c02e8ae5b9ad22c886b3525cf2f
+  md5: 2063bfd4964ea21b195867a0400437da
+  depends:
+  - cuda-cccl_linux-64
+  - cuda-cudart-static_linux-64
+  - cuda-cudart_linux-64
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 360187
+  timestamp: 1709678893687
+- kind: conda
+  name: cuda-cudart-static
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-12.4.99-hd3aeb46_0.conda
+  sha256: ee22ac9592a507832d491821333cea9748ec76445d406d2a8375410b42c60f86
+  md5: 7b26bf5d85c4c33b30dc9a602c1e4034
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart-static_linux-64 12.4.99 h59595ed_0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 22515
+  timestamp: 1709678919251
+- kind: conda
+  name: cuda-cudart-static_linux-64
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-12.4.99-h59595ed_0.conda
+  sha256: 40b2426c07b93859d73fd1f8dd07a9a80bd56e46d22adb0aee2ddfa87329a1a7
+  md5: b593aaade78e8cf4e9ca76bfea457c18
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 742145
+  timestamp: 1709678776950
+- kind: conda
+  name: cuda-cudart_linux-64
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.4.99-h59595ed_0.conda
+  sha256: dc8734b59e2765fdcf8c7765193af2fc5e8120ca1a47b9b2c13eb8789c20a781
+  md5: 2c184d2ca9f4e01b501103b42b895016
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 186659
+  timestamp: 1709678821888
+- kind: conda
+  name: cuda-cupti
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.4.99-h59595ed_0.conda
+  sha256: 4ddbf91be47a4758f33bbb991acf33fbd40a62139bc18eca9d91ee7fa3df7419
+  md5: 64e37ec49cb454099ae213683aeca0a2
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 1916553
+  timestamp: 1709670761969
+- kind: conda
+  name: cuda-driver-dev_linux-64
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-12.4.99-h59595ed_0.conda
+  sha256: 549ff4d4c8230074764ab5f7932979175561081862d8162e6e04d4587b445918
+  md5: 7d066cab928d7b91cdb6cf3823a86292
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 36008
+  timestamp: 1709678846246
+- kind: conda
+  name: cuda-nvcc
+  version: 12.4.99
+  build: hcdd1206_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.4.99-hcdd1206_0.conda
+  sha256: 218cfded554421908bb5259c561b22cc5e72f920f9439db5289bad3747e1e1b7
+  md5: 3c42e8861e1d031d648ade2c020c1645
+  depends:
+  - cuda-nvcc_linux-64 12.4.99.*
+  - gcc_linux-64
+  - gxx_linux-64
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 23356
+  timestamp: 1709739202801
+- kind: conda
+  name: cuda-nvcc-dev_linux-64
+  version: 12.4.99
+  build: ha770c72_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.4.99-ha770c72_0.conda
+  sha256: 2ad9930242a67da9ca59b037fbf95572b9230fd8ee4d113d262b9d51828874e4
+  md5: 89e80256386de8098204d9acc321e0e0
+  depends:
+  - cuda-crt-dev_linux-64 12.4.99 ha770c72_0
+  - cuda-nvvm-dev_linux-64 12.4.99 ha770c72_0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=6
+  constrains:
+  - gcc_impl_linux-64 >=6,<13
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 11209663
+  timestamp: 1709707720724
+- kind: conda
+  name: cuda-nvcc-impl
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-12.4.99-hd3aeb46_0.conda
+  sha256: df5f80e6041bca959beaa2a7823ffa8907fa24f151110f226dfc43d6a5f0d087
+  md5: 0d53e62509b871664683fd28a3404a5f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart >=12.4.99,<13.0a0
+  - cuda-cudart-dev
+  - cuda-nvcc-dev_linux-64 12.4.99 ha770c72_0
+  - cuda-nvcc-tools 12.4.99 hd3aeb46_0
+  - cuda-nvvm-impl 12.4.99 h59595ed_0
+  - cuda-version >=12.4,<12.5.0a0
+  constrains:
+  - gcc_impl_linux-64 >=6,<13
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 24407
+  timestamp: 1709707777010
+- kind: conda
+  name: cuda-nvcc-tools
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.4.99-hd3aeb46_0.conda
+  sha256: 204d3bde4f2307752698d878fe243182e7787a94687e76f3583ea0cbce16acf9
+  md5: 27d1557afe25487179cab80347683414
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-crt-tools 12.4.99 ha770c72_0
+  - cuda-nvvm-tools 12.4.99 h59595ed_0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - gcc_impl_linux-64 >=6,<13
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 23794631
+  timestamp: 1709707631662
+- kind: conda
+  name: cuda-nvcc_linux-64
+  version: 12.4.99
+  build: h8a487aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.4.99-h8a487aa_0.conda
+  sha256: f9e7f302c1b7bf2e51c19aa675b83ca01e4aea14170c7713fa33badde80adbec
+  md5: 2da6c881aaa9c34f70abf6af901d7ccc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart-dev_linux-64 12.4.*
+  - cuda-driver-dev_linux-64 12.4.*
+  - cuda-nvcc-dev_linux-64 12.4.99.*
+  - cuda-nvcc-impl 12.4.99.*
+  - cuda-nvcc-tools 12.4.99.*
+  - sysroot_linux-64 >=2.17,<3.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 25135
+  timestamp: 1709739196512
+- kind: conda
+  name: cuda-nvrtc
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.4.99-hd3aeb46_0.conda
+  sha256: 9c978552e486f68e3bc2e0ac85b71a7c2b36cdd0cb3aa61b597b833fa1d6c018
+  md5: 852b8118fc124419cb019de64f7d6443
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 18874204
+  timestamp: 1709673404039
+- kind: conda
+  name: cuda-nvtx
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.4.99-h59595ed_0.conda
+  sha256: b07f3e35720e65344a1c8e11afa50c1a499dfbaf317332b1c3b4154aa1253da8
+  md5: 1e0bebdf91c219cc93e7b17d9d9430d8
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 31493
+  timestamp: 1709672484598
+- kind: conda
+  name: cuda-nvvm-dev_linux-64
+  version: 12.4.99
+  build: ha770c72_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.4.99-ha770c72_0.conda
+  sha256: eb26974755aa0d5e7932a716a7329bc71601ff12520469fe6a268b71366303b5
+  md5: d9c219d29e84b26ced48afcf588acbae
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 24054
+  timestamp: 1709707478270
+- kind: conda
+  name: cuda-nvvm-impl
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-12.4.99-h59595ed_0.conda
+  sha256: 35cbd7ece333e6fcc3228dfe3479b54e72f69135e65f49986acbf0d91038ef80
+  md5: 150c9761963574876d37c6f5e6d5eb46
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 9016303
+  timestamp: 1709707524722
+- kind: conda
+  name: cuda-nvvm-tools
+  version: 12.4.99
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-12.4.99-h59595ed_0.conda
+  sha256: 9b921ee078308c1c5f9499b0f2b5db4dd7524396232c10a16227d8422531e9b6
+  md5: 4e1eb11e4e9eb812d85cb6da233a9612
+  depends:
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 11708917
+  timestamp: 1709707566416
+- kind: conda
+  name: cuda-version
+  version: '12.4'
+  build: h3060b56_3
+  build_number: 3
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.4-h3060b56_3.conda
+  sha256: 571d32fbd0dc8df6e85c14d1757549927e272af9c70b935d7e3a553ab0b0b4da
+  md5: c9a3fe8b957176e1a8452c6f3431b0d8
+  constrains:
+  - cudatoolkit 12.4|12.4.*
+  - __cuda >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 21022
+  timestamp: 1709765922936
+- kind: conda
+  name: cudnn
+  version: 8.9.7.29
+  build: h092f7fd_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.9.7.29-h092f7fd_3.conda
+  sha256: 27156736f5a0a30e6fb426f35216b903968b58bdf209d0a04b6eeb6530838456
+  md5: 2242eab289d88f2f819f8aee5aa49823
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-nvrtc
+  - cuda-version >=12.0,<13
+  - cuda-version >=12.0,<13.0a0
+  - libcublas
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.8.0.121-h838ba91_3.conda
-  hash:
-    md5: 23fe960de88644a27bf747f4c37dcac1
-    sha256: 0e591d4350c6f75af66533d944659fa51f562a259e06342e9a2f010d6f1f9b5c
-  build: h838ba91_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  constrains:
-  - __glibc >=2.17
   license: LicenseRef-cuDNN-Software-License-Agreement
-  size: 478677055
-  timestamp: 1693630909864
-- platform: linux-64
+  size: 468267309
+  timestamp: 1710307755197
+- kind: conda
   name: cycler
   version: 0.12.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 13458
   timestamp: 1696677888423
-- platform: linux-64
+- kind: conda
   name: dataclasses
   version: '0.8'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
-  hash:
-    md5: a362b2124b06aad102e2ee4581acee7d
-    sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
   build: pyhc8e2a94_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
+  sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
+  md5: a362b2124b06aad102e2ee4581acee7d
+  depends:
+  - python >=3.7
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 9870
   timestamp: 1628958582931
-- platform: linux-64
+- kind: conda
   name: dav1d
   version: 1.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  hash:
-    md5: 418c6ca5929a611cbd69204907a83995
-    sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
   size: 760229
   timestamp: 1685695754230
-- platform: linux-64
+- kind: conda
   name: debugpy
-  version: 1.8.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.8.1
+  build: py310hc6cd4ac_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py310hc6cd4ac_0.conda
+  sha256: 69d3970a9bb62d4e1e187f82248cc1cc924589c06100a6f1a065e063f4155978
+  md5: 1ea80564b80390fa25da16e4211eb801
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
-  hash:
-    md5: 01388b4ec9eed3b26fa732aa39745475
-    sha256: 77593f7b60d8f3b4d27a97a1b9e6c07c3f2490cfab77039d5e403166448b5de2
-  build: py310hc6cd4ac_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
-  size: 2436014
-  timestamp: 1695534502620
-- platform: linux-64
+  size: 1917514
+  timestamp: 1707444642761
+- kind: conda
   name: decorator
   version: 5.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 12072
   timestamp: 1641555714315
-- platform: linux-64
+- kind: conda
   name: defusedxml
   version: 0.7.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 961b3a227b437d82ad7054484cfa71b2
-    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 24062
   timestamp: 1615232388757
-- platform: linux-64
+- kind: conda
   name: dm-env
   version: '1.6'
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/dm-env-1.6-pyhd8ed1ab_0.conda
+  sha256: 3c3b78a68720048a20b4b99e0906e8878ea9122cb2274c48fb437c7bc57e53e6
+  md5: 7cca3d9dac82ab7ddcdcf37bd07c857d
+  depends:
   - absl-py
   - dm-tree
   - numpy
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/dm-env-1.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7cca3d9dac82ab7ddcdcf37bd07c857d
-    sha256: 3c3b78a68720048a20b4b99e0906e8878ea9122cb2274c48fb437c7bc57e53e6
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 24905
   timestamp: 1671606125268
-- platform: linux-64
+- kind: conda
   name: dm-tree
   version: 0.1.8
-  category: main
-  manager: conda
-  dependencies:
+  build: py310ha8c1f0e_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/dm-tree-0.1.8-py310ha8c1f0e_4.conda
+  sha256: a7e4f5565856370a75247100f87f9b4afefdb7f0eeced4709ad31f9676af65ac
+  md5: d099355e8706f6c981147baec066269a
+  depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/dm-tree-0.1.8-py310h620c231_2.conda
-  hash:
-    md5: da4d8bcd15f63b5fe147ad35d7204036
-    sha256: 976e99d29d5025cd8b0e4f154c2ff6fde76ac2ac58250551354f543ca9757193
-  build: py310h620c231_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: Apache-2.0
   license_family: Apache
-  size: 106812
-  timestamp: 1695579895146
-- platform: linux-64
+  size: 106907
+  timestamp: 1709886929256
+- kind: conda
   name: entrypoints
   version: '0.4'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
   license: MIT
   license_family: MIT
-  noarch: python
   size: 9199
   timestamp: 1643888357950
-- platform: linux-64
+- kind: conda
   name: etils
-  version: 1.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/etils-1.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6cb0d8215eb44750a873dfa269b140cd
-    sha256: c2a433abb46ade6def6b3288fc6a7a3b493780ca8e885bb5e307f2387d57aa8b
+  version: 1.7.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/etils-1.7.0-pyhd8ed1ab_0.conda
+  sha256: 736273bb2dcb943e4850aa2690e43d7f4f48a4b6f643634d38a97ef20583db55
+  md5: 7d62c8b4cfeb701ac8537cca4342e4ec
+  depends:
+  - python >=3.10
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 766674
-  timestamp: 1698178135096
-- platform: linux-64
+  size: 776569
+  timestamp: 1708071217645
+- kind: conda
   name: exceptiongroup
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
+  version: 1.2.0
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: noarch
   noarch: python
-  size: 19262
-  timestamp: 1692026296517
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+  depends:
+  - python >=3.7
+  license: MIT and PSF-2.0
+  size: 20551
+  timestamp: 1704921321122
+- kind: conda
   name: executing
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
   license: MIT
   license_family: MIT
-  noarch: python
   size: 27689
   timestamp: 1698580072627
-- platform: linux-64
-  name: expat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libexpat 2.5.0 hcb278e6_1
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 8b9b5aca60558d02ddaa09d599e55920
-    sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  build: hcb278e6_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 136778
-  timestamp: 1680190541750
-- platform: linux-64
+- kind: conda
   name: ffmpeg
-  version: 6.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - aom >=3.6.1,<3.7.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.2.1,<7.0a0
-  - gnutls >=3.7.8,<3.8.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libgcc-ng >=12
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libva >=2.20.0,<3.0a0
-  - libvpx >=1.13.0,<1.14.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.3.1,<2.3.2.0a0
-  - svt-av1 >=1.7.0,<1.7.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.0.0-gpl_h334edf3_105.conda
-  hash:
-    md5: d47c3e10d2ca5fc07107d4ac640603da
-    sha256: f1f9070190bc189b9ec9034e9d9adbbb530cd25b571c763b33585195c0e13813
-  build: gpl_h334edf3_105
-  arch: x86_64
+  version: 4.4.0
+  build: h6987444_4
+  build_number: 4
   subdir: linux-64
-  build_number: 105
-  license: GPL-2.0-or-later
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-4.4.0-h6987444_4.tar.bz2
+  sha256: 11adb192292aeaaf770c71f47c246be5b51854366ec43a6f1eba8e0c3f9590f1
+  md5: cf5737e10b20f18ce8b25e81960671c7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gmp >=6.2.1,<7.0a0
+  - gnutls >=3.6.13,<3.7.0a0
+  - lame >=3.100,<3.101.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libvpx >=1.11.0,<1.12.0a0
+  - libxml2 >=2.9.12,<3.0.0a0
+  - libzlib >=1.2.11,<1.3.0a0
+  - openh264 >=2.1.1,<2.2.0a0
+  - x264 >=1!161.3030,<1!162
+  - x265
+  license: GPL-3.0-or-later
   license_family: GPL
-  size: 9863087
-  timestamp: 1696214559606
-- platform: linux-64
+  size: 10388904
+  timestamp: 1635121951178
+- kind: conda
   name: flask
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.0.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.2-pyhd8ed1ab_0.conda
+  sha256: d5bfe0e74b001572135bef51ffa329fa2f5dfd37fb87b2878ed851025ced9334
+  md5: 7f88df670921cc31c309719e30c22021
+  depends:
   - blinker >=1.6.2
   - click >=8.1.3
   - importlib-metadata >=3.6.0
@@ -1239,47 +1557,37 @@ package:
   - jinja2 >=3.1.2
   - python >=3.8
   - werkzeug >=3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d26105227a24c82fdf160f20ed379400
-    sha256: 73dafd8c1ae9ee9e42e5fa78275c8dc3b456879d83dc6d6ed82d92bd498c9184
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 79578
-  timestamp: 1696349275299
-- platform: linux-64
+  size: 80485
+  timestamp: 1707044052869
+- kind: conda
   name: flask-cors
   version: 4.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-cors-4.0.0-pyhd8ed1ab_0.conda
+  sha256: bc23c15ab33e10f931b03e4f2812d30491c27e09ea6e6441c67ee2ed523ee06b
+  md5: 3dc2a99c1c76e3f4307ebaebfda0af4a
+  depends:
   - flask >=0.9
   - python >=3.6
   - six
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-cors-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3dc2a99c1c76e3f4307ebaebfda0af4a
-    sha256: bc23c15ab33e10f931b03e4f2812d30491c27e09ea6e6441c67ee2ed523ee06b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 17899
   timestamp: 1687783565818
-- platform: linux-64
+- kind: conda
   name: flax
-  version: 0.7.5
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.8.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/flax-0.8.2-pyhd8ed1ab_0.conda
+  sha256: ba547d4310cdd07f695e2559d18d5d15da253647ddda98f7167102059e90f0a2
+  md5: afd6b6c813edde816ab20e0e62cad7ca
+  depends:
   - jax >=0.4.11
   - matplotlib-base
   - msgpack-python
@@ -1291,567 +1599,442 @@ package:
   - rich >=11.1.0
   - tensorstore
   - typing_extensions >=4.2.0
-  url: https://conda.anaconda.org/conda-forge/noarch/flax-0.7.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4256f35452e531bcca39cb019ed52308
-    sha256: 12092562e180d567a99d567281bd53440e427b70d761e33a47227a8fbde4ec29
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
-  noarch: python
-  size: 173031
-  timestamp: 1699497432018
-- platform: linux-64
-  name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  build: hab24e00_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 397370
-  timestamp: 1566932522327
-- platform: linux-64
-  name: font-ttf-inconsolata
-  version: '3.000'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  build: h77eed37_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: OFL-1.1
-  license_family: Other
-  noarch: generic
-  size: 96530
-  timestamp: 1620479909603
-- platform: linux-64
-  name: font-ttf-source-code-pro
-  version: '2.038'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  build: h77eed37_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: OFL-1.1
-  license_family: Other
-  noarch: generic
-  size: 700814
-  timestamp: 1620479612257
-- platform: linux-64
-  name: font-ttf-ubuntu
-  version: '0.83'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
-  hash:
-    md5: 19410c3df09dfb12d1206132a1d357c5
-    sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
-  build: hab24e00_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Ubuntu Font Licence Version 1.0
-  license_family: Other
-  noarch: generic
-  size: 1961279
-  timestamp: 1566932680646
-- platform: linux-64
-  name: fontconfig
-  version: 2.14.2
-  category: main
-  manager: conda
-  dependencies:
-  - expat >=2.5.0,<3.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libgcc-ng >=12
-  - libuuid >=2.32.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
-  hash:
-    md5: 0f69b688f52ff6da70bccb7ff7001d1d
-    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  build: h14ed4e7_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 272010
-  timestamp: 1674828850194
-- platform: linux-64
-  name: fonts-conda-ecosystem
-  version: '1'
-  category: main
-  manager: conda
-  dependencies:
-  - fonts-conda-forge
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  build: '0'
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 3667
-  timestamp: 1566974674465
-- platform: linux-64
-  name: fonts-conda-forge
-  version: '1'
-  category: main
-  manager: conda
-  dependencies:
-  - font-ttf-dejavu-sans-mono
-  - font-ttf-inconsolata
-  - font-ttf-source-code-pro
-  - font-ttf-ubuntu
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  build: '0'
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 4102
-  timestamp: 1566932280397
-- platform: linux-64
+  license_family: APACHE
+  size: 509123
+  timestamp: 1710420504459
+- kind: conda
   name: fonttools
-  version: 4.44.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.49.0
+  build: py310h2372a71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.49.0-py310h2372a71_0.conda
+  sha256: 7aac51cdb7364f1534c352e15ecdd3d4f9b3889112e9b9716fa76bda9926a805
+  md5: e61ae80fde506b70a88e5e06376d2068
+  depends:
   - brotli
   - libgcc-ng >=12
   - munkres
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - unicodedata2 >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.44.0-py310h2372a71_0.conda
-  hash:
-    md5: 3d1677945147b2d6eb0fef35e98e650f
-    sha256: 7db0b07b04562531bc27df8a19674b4879ee3efe576d929335e159e2459e5018
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  size: 2235728
-  timestamp: 1699023764768
-- platform: linux-64
+  size: 2283569
+  timestamp: 1708049341447
+- kind: conda
   name: fqdn
   version: 1.5.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
   - cached-property >=1.3.0
   - python >=2.7,<4
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MPL-2.0
   license_family: MOZILLA
-  noarch: python
   size: 14395
   timestamp: 1638810388635
-- platform: linux-64
+- kind: conda
   name: freetype
   version: 2.12.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h267a509_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
-  hash:
-    md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
-    sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
-  build: h267a509_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
-- platform: linux-64
-  name: fribidi
-  version: 1.0.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-  hash:
-    md5: ac7bc6a654f8f41b352b38f4051135f8
-    sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
-  build: h36c2ea0_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1
-  size: 114383
-  timestamp: 1604416621168
-- platform: linux-64
+- kind: conda
   name: fsspec
-  version: 2023.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
-  hash:
-    md5: 5b86cf1ceaaa9be2ec4627377e538db1
-    sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+  version: 2024.3.0
   build: pyhca7485f_0
-  arch: x86_64
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.0-pyhca7485f_0.conda
+  sha256: 3329551042b00f92210e69ca9b14ea67897b0d6737a06b9f51b31fb7ca337dc7
+  md5: 30e975286171f6d96b0caf5498fb0634
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  size: 129095
+  timestamp: 1710607943955
+- kind: conda
+  name: gcc_impl_linux-64
+  version: 12.3.0
+  build: he2b93b0_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
+  sha256: a87826c55e6aa2ed5d17f267e6a583f7951658afaa4bf45cd5ba97f5583608b9
+  md5: e89827619e73df59496c708b94f6f3d5
+  depends:
+  - binutils_impl_linux-64 >=2.39
+  - libgcc-devel_linux-64 12.3.0 h8bca6fd_105
+  - libgcc-ng >=12.3.0
+  - libgomp >=12.3.0
+  - libsanitizer 12.3.0 h0f45ef3_5
+  - libstdcxx-ng >=12.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 51856676
+  timestamp: 1706820019081
+- kind: conda
+  name: gcc_linux-64
+  version: 12.3.0
+  build: h6477408_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
+  sha256: 836692c3d4948f25a19f9071db40f7788edcb342d771786a206a6a122f92365d
+  md5: 7a53f84c45bdf4656ba27b9e9ed68b3d
+  depends:
+  - binutils_linux-64 2.40 hdade7a5_3
+  - gcc_impl_linux-64 12.3.0.*
+  - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 124907
-  timestamp: 1697919506326
-- platform: linux-64
-  name: gettext
-  version: 0.21.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 14947d8770185e5153fdd04d4673ed37
-    sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  build: h27087fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4320628
-  timestamp: 1665673494324
-- platform: linux-64
+  size: 30977
+  timestamp: 1710260096918
+- kind: conda
   name: glfw
-  version: 3.3.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxcursor
-  - xorg-libxinerama >=1.1.5,<1.2.0a0
-  - xorg-libxrandr
-  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.3.8-hd590300_2.conda
-  hash:
-    md5: 2ff0316a1405840d87b4f451f4f9e033
-    sha256: a3b95a49d5a67b57cda02e97c25208d3a1ff631b8d8ddac00779e4f348bc52c5
-  build: hd590300_2
-  arch: x86_64
+  version: '3.4'
+  build: hd590300_0
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+  sha256: 852298b9d1b6e58d8653d943049f7bce0ef3774c87fccd5ac1e8b04d5d702d40
+  md5: 4c7a044d25e000fef39b77c10a102ea1
+  depends:
+  - libgcc-ng >=12
+  - libxkbcommon >=1.6.0,<2.0a0
+  - wayland >=1.22.0,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
   license: Zlib
-  size: 126785
-  timestamp: 1699107436116
-- platform: linux-64
+  size: 167421
+  timestamp: 1708788896752
+- kind: conda
   name: gmp
-  version: 6.2.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 6.3.0
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+  sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
+  md5: e358c7c5f6824c272b5034b3816438a7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 569852
+  timestamp: 1710169507479
+- kind: conda
+  name: gnutls
+  version: 3.6.13
+  build: h85f3911_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+  sha256: 6c9307f0fedce2c4d060bba9ac888b300bc0912effab423d67b8e1b661a93305
+  md5: 7d1b6fff16c1431d96cb4934938799fd
+  depends:
   - libgcc-ng >=7.5.0
   - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
-  hash:
-    md5: b94cf2db16066b242ebd26db2facbd56
-    sha256: 07a5319e1ac54fe5d38f50c60f7485af7f830b036da56957d0bfb7558a886198
-  build: h58526e2_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 825784
-  timestamp: 1605751468661
-- platform: linux-64
-  name: gnutls
-  version: 3.7.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libidn2 >=2,<3.0a0
-  - libstdcxx-ng >=12
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.8.1,<3.9.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.8-hf3e180e_0.tar.bz2
-  hash:
-    md5: cbe8e27140d67c3f30e01cfb642a6e7c
-    sha256: 4a47e4558395b98fff4c1c44ad358dade62b350a03b5a784d4bc589d6eb7ac9e
-  build: hf3e180e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - nettle >=3.4.1
+  - nettle >=3.6,<3.7.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 2271927
-  timestamp: 1664445361111
-- platform: linux-64
-  name: graphite2
-  version: 1.3.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
-  hash:
-    md5: 8c54672728e8ec6aa6db90cf2806d220
-    sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
-  build: h58526e2_1001
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1001
-  license: LGPLv2
-  size: 104701
-  timestamp: 1604365484436
-- platform: linux-64
+  size: 2096527
+  timestamp: 1605742597225
+- kind: conda
   name: grpcio
-  version: 1.58.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.62.1
+  build: py310h1b8f574_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.1-py310h1b8f574_0.conda
+  sha256: 4e149efa7471186c232f6f066ce744ee3d1a2c2023cd3a7307dc49d34c5450e0
+  md5: 12d953659f34036237738a4e104b7da5
+  depends:
   - libgcc-ng >=12
-  - libgrpc 1.58.2 he06187c_0
+  - libgrpc 1.62.1 h15f2491_0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.58.2-py310h1b8f574_0.conda
-  hash:
-    md5: 9fc059a86c7a52165dc4c72379377439
-    sha256: c60cce0991279289f27dd87a7d50f1018a5c84ebf6772512499d5c598e569409
-  build: py310h1b8f574_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 993759
-  timestamp: 1698719164224
-- platform: linux-64
+  size: 1004149
+  timestamp: 1709938224449
+- kind: conda
+  name: gxx_impl_linux-64
+  version: 12.3.0
+  build: he2b93b0_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_5.conda
+  sha256: 69371a1e8ad718b033bc1c58743a395e06ad19d08a2ff97e264ed82fd3ccbd9c
+  md5: cddba8fd94e52012abea1caad722b9c2
+  depends:
+  - gcc_impl_linux-64 12.3.0 he2b93b0_5
+  - libstdcxx-devel_linux-64 12.3.0 h8bca6fd_105
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 12742481
+  timestamp: 1706820327015
+- kind: conda
+  name: gxx_linux-64
+  version: 12.3.0
+  build: h4a1b8e8_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h4a1b8e8_3.conda
+  sha256: 5a842fc69c03ac513a2c021f3f21afd9d9ca50b10b95c0dcd236aa77d6d42373
+  md5: 9ec22c7c544f4a4f6d660f0a3b0fd15c
+  depends:
+  - binutils_linux-64 2.40 hdade7a5_3
+  - gcc_linux-64 12.3.0 h6477408_3
+  - gxx_impl_linux-64 12.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29304
+  timestamp: 1710260169322
+- kind: conda
   name: gym
   version: 0.26.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py310hfdc917e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gym-0.26.1-py310hfdc917e_0.conda
+  sha256: 8803fa35d20a69f4873b9d1ba7d8b27c51c2130ff3b3dd80b603eace52950551
+  md5: 64bf2cb1bf7216b6f612b05e73404511
+  depends:
   - cloudpickle >=1.2.0
   - gym-notices
   - numpy >=1.21.6,<2.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/gym-0.26.1-py310hfdc917e_0.conda
-  hash:
-    md5: 64bf2cb1bf7216b6f612b05e73404511
-    sha256: 8803fa35d20a69f4873b9d1ba7d8b27c51c2130ff3b3dd80b603eace52950551
-  build: py310hfdc917e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 862224
   timestamp: 1673317603280
-- platform: linux-64
+- kind: conda
   name: gym-notices
   version: 0.0.8
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/gym-notices-0.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba6bbf819531ebeab48748c1ea372ea9
-    sha256: 19c5fddb7a4771ac069ee38622bb2bdc6c19965ba9b6808e2a6a6b638fdb1893
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/gym-notices-0.0.8-pyhd8ed1ab_0.conda
+  sha256: 19c5fddb7a4771ac069ee38622bb2bdc6c19965ba9b6808e2a6a6b638fdb1893
+  md5: ba6bbf819531ebeab48748c1ea372ea9
+  depends:
+  - python >=3.6
   license: MIT
   license_family: MIT
-  noarch: python
   size: 8533
   timestamp: 1671541814069
-- platform: linux-64
-  name: harfbuzz
-  version: 8.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - cairo >=1.16.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
-  hash:
-    md5: 98db5f8813f45e2b29766aff0e4a499c
-    sha256: 5ca6585e6a4348bcbe214d57f5d6f560d15d23a6650770a2909475848b214edb
-  build: h3d44ed6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+- kind: conda
+  name: h11
+  version: 0.14.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  md5: b21ed0883505ba1910994f1df031a428
+  depends:
+  - python >=3
+  - typing_extensions
   license: MIT
   license_family: MIT
-  size: 1526592
-  timestamp: 1695089914042
-- platform: linux-64
+  size: 48251
+  timestamp: 1664132995560
+- kind: conda
+  name: h2
+  version: 4.1.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  size: 46754
+  timestamp: 1634280590080
+- kind: conda
+  name: hpack
+  version: 4.0.0
+  build: pyh9f0ad1d_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25341
+  timestamp: 1598856368685
+- kind: conda
+  name: httpcore
+  version: 1.0.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.4-pyhd8ed1ab_0.conda
+  sha256: dec07ca00223d52433e7c20c71d5e645a7828b3e50206d855ad7a540869341f2
+  md5: 20f047662cf4fa8b97836111df87dbb4
+  depends:
+  - anyio >=3.0,<5.0
+  - certifi
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - python >=3.8
+  - sniffio 1.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45727
+  timestamp: 1708529429006
+- kind: conda
+  name: httpx
+  version: 0.27.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  md5: 9f359af5a886fd6ca6b2b6ea02e58332
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.8
+  - sniffio
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64651
+  timestamp: 1708531043505
+- kind: conda
+  name: hyperframe
+  version: 6.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14646
+  timestamp: 1619110249723
+- kind: conda
   name: icu
   version: '73.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-  hash:
-    md5: cc47e1facc155f91abd89b11e48e72ff
-    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 12089150
   timestamp: 1692900650789
-- platform: linux-64
+- kind: conda
   name: idna
-  version: '3.4'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 34272b248891bddccc64479f9a7fffed
-    sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+  version: '3.6'
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+  md5: 1a76f09108576397c41c0b0c5bd84134
+  depends:
+  - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 56742
-  timestamp: 1663625484114
-- platform: linux-64
+  size: 50124
+  timestamp: 1701027126206
+- kind: conda
   name: importlib-metadata
-  version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 7.0.2
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.2-pyha770c72_0.conda
+  sha256: 9a26136d2cc81ccac209d6ae24281ceba3365fe34e34b2c45570f2a96e9d9c1b
+  md5: b050a4bb0e90ebd6e7fa4093d6346867
+  depends:
   - python >=3.8
   - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
-  hash:
-    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
-    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 25910
-  timestamp: 1688754651944
-- platform: linux-64
+  size: 26900
+  timestamp: 1709821273570
+- kind: conda
   name: importlib_metadata
-  version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=6.8.0,<6.8.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: b279b07ce18058034e5b3606ba103a8b
-    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
+  version: 7.0.2
   build: hd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.2-hd8ed1ab_0.conda
+  sha256: b250e6a3e741b762bb2caf05119feb6245cb41b468542e5a9263cd01671098f7
+  md5: d11132727a247f2c1998779a2af743a1
+  depends:
+  - importlib-metadata >=7.0.2,<7.0.3.0a0
   license: Apache-2.0
   license_family: APACHE
-  noarch: generic
-  size: 9428
-  timestamp: 1688754660209
-- platform: linux-64
+  size: 9439
+  timestamp: 1709821278370
+- kind: conda
   name: importlib_resources
-  version: 6.1.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 6.3.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.3.0-pyhd8ed1ab_0.conda
+  sha256: 8ad2fdd72f6a0ebefaa1496d2f43f100596f1733468fd9b549891f6195a5b8cb
+  md5: 18850e65ca439066484607b26ed09ecd
+  depends:
   - python >=3.8
   - zipp >=3.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d5fa25cf42f3f32a12b2d874ace8574
-    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - importlib-resources >=6.1.1,<6.1.2.0a0
+  - importlib-resources >=6.3.0,<6.3.1.0a0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 29951
-  timestamp: 1699364734111
-- platform: linux-64
+  size: 30938
+  timestamp: 1710342936493
+- kind: conda
   name: ipykernel
-  version: 6.26.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 6.29.3
+  build: pyhd33586a_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyhd33586a_0.conda
+  sha256: 0314f15e666fd9a4fb653aae37d2cf4dc6bc3a18c0d9c2671a6a0783146adcfa
+  md5: e0deff12c601ce5cb7476f93718f3168
+  depends:
   - __linux
   - comm >=0.1.1
   - debugpy >=1.6.5
@@ -1863,164 +2046,141 @@ package:
   - packaging
   - psutil
   - python >=3.8
-  - pyzmq >=20
+  - pyzmq >=24
   - tornado >=6.1
   - traitlets >=5.4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
-  hash:
-    md5: 2307f71f5f0896d4b91b93e6b468abff
-    sha256: 9e647454f7572101657a07820ebed294df9a6a527b041cd5e4dd98b8aa3db625
-  build: pyhf8b6a83_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 116210
-  timestamp: 1698244196564
-- platform: linux-64
+  size: 119050
+  timestamp: 1708996727913
+- kind: conda
   name: ipython
-  version: 8.17.2
-  category: main
-  manager: conda
-  dependencies:
-  - __linux
+  version: 8.22.2
+  build: pyh707e725_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
+  sha256: 7740505317669f094c881537a643ed26977e209510965164d84942799c997d42
+  md5: f0abe827c8a7c6d91bccdf90cb1fbee3
+  depends:
+  - __unix
   - decorator
   - exceptiongroup
   - jedi >=0.16
   - matplotlib-inline
   - pexpect >4.3
   - pickleshare
-  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - prompt-toolkit >=3.0.41,<3.1.0
   - pygments >=2.4.0
-  - python >=3.9
+  - python >=3.10
   - stack_data
-  - traitlets >=5
+  - traitlets >=5.13.0
   - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
-  hash:
-    md5: f39d0b60e268fe547f1367edbab457d4
-    sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
-  build: pyh41d4057_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 589731
-  timestamp: 1698846745397
-- platform: linux-64
+  size: 593746
+  timestamp: 1709559868257
+- kind: conda
   name: isoduration
   version: 20.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
   - arrow >=0.15.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 17189
   timestamp: 1638811664194
-- platform: linux-64
+- kind: conda
   name: itsdangerous
   version: 2.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3c3de74912f11d2b590184f03c7cd09b
-    sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
+  md5: 3c3de74912f11d2b590184f03c7cd09b
+  depends:
+  - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 16377
   timestamp: 1648147263536
-- platform: linux-64
+- kind: conda
   name: jax
-  version: 0.4.19
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.4.25
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jax-0.4.25-pyhd8ed1ab_0.conda
+  sha256: e21479fc9b50d9906b9b41e46630b049c0ef3fcd01e097c4c28b45be02f10faf
+  md5: c4c729f7c77da9ef637d9970f4f6d980
+  depends:
   - importlib_metadata >=4.6
-  - jaxlib >=0.4.14
+  - jaxlib >=0.4.20
   - ml_dtypes >=0.2.0
   - numpy >=1.22
   - opt-einsum
   - python >=3.9
   - scipy >=1.9
-  url: https://conda.anaconda.org/conda-forge/noarch/jax-0.4.19-pyhd8ed1ab_0.conda
-  hash:
-    md5: 97905d83c1f1a75bd6f1513b1946c3f9
-    sha256: 88f3962fec1bb13387fe1782d50f88bcfd2660d75f02e4df9dc2d9188d9b2db4
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 1104184
-  timestamp: 1698427283102
-- platform: linux-64
+  size: 1194295
+  timestamp: 1709239812310
+- kind: conda
   name: jaxlib
-  version: 0.4.19
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.4.23
+  build: cuda120py310h3cc97ca_200
+  build_number: 200
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.4.23-cuda120py310h3cc97ca_200.conda
+  sha256: 68d972ed5e4c4778a186654283c7f74cf7c27287462ec6d1be7192ca72084045
+  md5: 3210decd3a5135592f5bcac5fb7e58cf
+  depends:
   - __cuda
-  - __glibc >=2.17
-  - cudatoolkit >=11.8,<12
-  - cudnn >=8.8.0.121,<9.0a0
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart >=12.0.107,<13.0a0
+  - cuda-nvtx >=12.0.76,<13.0a0
+  - cuda-version >=12.0,<13
+  - cudnn >=8.9.7.29,<9.0a0
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcublas >=12.0.1.189,<13.0a0
+  - libcufft >=11.0.0.21,<12.0a0
+  - libcurand >=10.3.1.50,<11.0a0
+  - libcusolver >=11.4.2.57,<12.0a0
+  - libcusparse >=12.0.0.76,<13.0a0
   - libgcc-ng >=12
-  - libgrpc >=1.58.1,<1.59.0a0
+  - libgrpc >=1.62.1,<1.63.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - ml_dtypes >=0.2.0
-  - nccl >=2.19.3.1,<3.0a0
+  - nccl >=2.20.5.1,<3.0a0
   - numpy >=1.22.4,<2.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  - scipy >=1.7
-  url: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.4.19-cuda118py310ha8ecd4c_200.conda
-  hash:
-    md5: 38211b17cb2a68c2a390f4c96053cbd4
-    sha256: d01f8b0bd976b7565cef01610f3865e05ba15c11af3418b3a88a8b5c2aa6a01a
-  build: cuda118py310ha8ecd4c_200
-  arch: x86_64
-  subdir: linux-64
-  build_number: 200
+  - scipy >=1.9
   constrains:
-  - jax >=0.4.19
+  - jax >=0.4.23
   license: Apache-2.0
-  license_family: APACHE
-  size: 98587764
-  timestamp: 1698242718159
-- platform: linux-64
+  size: 88123972
+  timestamp: 1710644147270
+- kind: conda
   name: jaxopt
-  version: 0.8.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.8.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jaxopt-0.8.3-pyhd8ed1ab_0.conda
+  sha256: c649701eec4f46e882e0c49f0811451ece52a06c353ddfd8d0bd7adf841d3b7c
+  md5: c7e527657be37dff8a07ea234ccb0ad1
+  depends:
   - absl-py
   - jax >=0.2.18
   - jaxlib >=0.1.69
@@ -2028,107 +2188,82 @@ package:
   - numpy >=1.18.4
   - python >=3.7
   - scipy >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/jaxopt-0.8.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b4def6bfe14dba07b1e5677e453e618c
-    sha256: 2b919550114946d60fbac16040a15276e15c493ccc7179dbe7b325d22631f4c2
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 102429
-  timestamp: 1699277681732
-- platform: linux-64
+  size: 103119
+  timestamp: 1704895349124
+- kind: conda
   name: jedi
   version: 0.19.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
   - parso >=0.8.3,<0.9.0
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 841312
   timestamp: 1696326218364
-- platform: linux-64
+- kind: conda
   name: jinja2
-  version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.1.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
+  sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
+  md5: e7d8df6509ba635247ff9aea31134262
+  depends:
   - markupsafe >=2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 101443
-  timestamp: 1654302514195
-- platform: linux-64
+  size: 111589
+  timestamp: 1704967140287
+- kind: conda
   name: json5
-  version: 0.9.14
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7,<4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: dac1dabba2b5a9d1aee175c5fcc7b436
-    sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
+  version: 0.9.24
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
+  subdir: noarch
   noarch: python
-  size: 25003
-  timestamp: 1688248468479
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
+  sha256: 148a427d4867ecd367b2bb9c2ef11ae7795abeabc8454f802f28ff692b3ce1aa
+  md5: fc9780a517b51ea3798fc011c17ffd51
+  depends:
+  - python >=3.7,<4.0
+  license: Apache-2.0
+  size: 27927
+  timestamp: 1710632397456
+- kind: conda
   name: jsonpointer
   version: '2.4'
-  category: main
-  manager: conda
-  dependencies:
+  build: py310hff52083_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+  sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
+  md5: 08ec1463dbc5c806a32fc431874032ca
+  depends:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
-  hash:
-    md5: 08ec1463dbc5c806a32fc431874032ca
-    sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
-  build: py310hff52083_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: BSD-3-Clause
   license_family: BSD
   size: 16170
   timestamp: 1695397381208
-- platform: linux-64
+- kind: conda
   name: jsonschema
-  version: 4.19.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.21.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+  sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
+  md5: 8a3a3d01629da20befa340919e3dd2c4
+  depends:
   - attrs >=22.2.0
   - importlib_resources >=1.4.0
   - jsonschema-specifications >=2023.03.6
@@ -2136,98 +2271,78 @@ package:
   - python >=3.8
   - referencing >=0.28.4
   - rpds-py >=0.7.1
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24d41c2f9cc199d0a180ecf7ef54739c
-    sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 71509
-  timestamp: 1698678642652
-- platform: linux-64
+  size: 72817
+  timestamp: 1705707712082
+- kind: conda
   name: jsonschema-specifications
-  version: 2023.7.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 2023.12.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+  sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+  md5: a0e4efb5f35786a05af4809a2fb1f855
+  depends:
   - importlib_resources >=1.4.0
   - python >=3.8
-  - referencing >=0.25.0
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
-    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - referencing >=0.31.0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 15296
-  timestamp: 1689701341221
-- platform: linux-64
+  size: 16431
+  timestamp: 1703778502971
+- kind: conda
   name: jsonschema-with-format-nongpl
-  version: 4.19.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.21.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
+  sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
+  md5: 26bce4b5405738c09304d4f4796b2c2a
+  depends:
   - fqdn
   - idna
   - isoduration
   - jsonpointer >1.13
-  - jsonschema >=4.19.2,<4.19.3.0a0
+  - jsonschema >=4.21.1,<4.21.2.0a0
   - python
   - rfc3339-validator
   - rfc3986-validator >0.1.0
   - uri-template
   - webcolors >=1.11
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: c447b7c28ad6bb3306f0015f1195c721
-    sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 7389
-  timestamp: 1698678669876
-- platform: linux-64
+  size: 7452
+  timestamp: 1705707742938
+- kind: conda
   name: jupyter-lsp
-  version: 2.2.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.2.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
+  sha256: 8000b1904a2a10cf039b46305781128e1a93da4c2fd857445b4924ecf3535bdb
+  md5: 91f93e1ebf6535be518715432d89fd92
+  depends:
   - importlib-metadata >=4.8.3
   - jupyter_server >=1.1.2
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
-    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 52525
-  timestamp: 1685453825227
-- platform: linux-64
+  size: 55303
+  timestamp: 1709672683901
+- kind: conda
   name: jupyter_client
-  version: 8.6.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 8.6.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+  sha256: c7d10d7941fd2e61480e49d3b2b21a530af4ae4b0d449a1746a72a38bacb63e2
+  md5: c03972cfce69ad913d520c652e5ed908
+  depends:
   - importlib_metadata >=4.8.3
   - jupyter_core >=4.12,!=5.0.*
   - python >=3.8
@@ -2235,47 +2350,37 @@ package:
   - pyzmq >=23.0
   - tornado >=6.2
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bd3f1069cdebb44c7ae9efb900e312d
-    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 105838
-  timestamp: 1699284056169
-- platform: linux-64
+  size: 106042
+  timestamp: 1710255955150
+- kind: conda
   name: jupyter_core
-  version: 5.5.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 5.7.2
+  build: py310hff52083_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py310hff52083_0.conda
+  sha256: 837039256d39a249b5bec850f87948e1967c47c9e747056df8155d80c4d3b094
+  md5: cb92c27600d5716fd526a206aa43342c
+  depends:
   - platformdirs >=2.5
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
-  hash:
-    md5: 9ca8f0d07c512cef3fd07b121bb2b023
-    sha256: 35e05ff1ad8b070b1378886c5ee4b82a000ea078494af6d0552d1c455b3f6220
-  build: py310hff52083_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 79275
-  timestamp: 1698673792929
-- platform: linux-64
+  size: 79565
+  timestamp: 1710257392136
+- kind: conda
   name: jupyter_events
-  version: 0.9.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.9.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.1-pyhd8ed1ab_0.conda
+  sha256: 9054dea8926daf867ee0f366b3b45579e1bd16cbc7667d1f7541531d037fdbfd
+  md5: 331ea2fc883fc5f2fc002a4e66e38bc5
+  depends:
   - jsonschema-with-format-nongpl >=4.18.0
   - python >=3.8
   - python-json-logger >=2.0.4
@@ -2284,31 +2389,26 @@ package:
   - rfc3339-validator
   - rfc3986-validator >=0.1.1
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00ba25993f0dba38cf72a7224e33289f
-    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 21354
-  timestamp: 1699286038042
-- platform: linux-64
+  size: 21271
+  timestamp: 1710262753295
+- kind: conda
   name: jupyter_server
-  version: 2.10.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.13.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+  sha256: 7e3259506b1b8500ebac4b4b097629ca8c32ee70d1c1df122052fea65c7cbae0
+  md5: e242df505f194c4932fbb840a99207e2
+  depends:
   - anyio >=3.1.0
   - argon2-cffi
   - jinja2
   - jupyter_client >=7.4.4
   - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.6.0
+  - jupyter_events >=0.9.0
   - jupyter_server_terminals
   - nbconvert-core >=6.4.4
   - nbformat >=5.3.0
@@ -2322,47 +2422,38 @@ package:
   - tornado >=6.2.0
   - traitlets >=5.6.0
   - websocket-client
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.10.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 016d56f5d81b9364d1da5f4895a2a9f8
-    sha256: 0b9a72f28ff8a12e6ea0ae43d3ea93e288074d29348c5fc6fbb3a5e5e18b2ecd
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 316607
-  timestamp: 1699289600334
-- platform: linux-64
+  size: 324502
+  timestamp: 1709563426862
+- kind: conda
   name: jupyter_server_terminals
-  version: 0.4.4
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.5.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
   - python >=3.8
   - terminado >=0.8.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 7c0965e1d4a0ee1529e8eaa03a78a5b3
-    sha256: 9f4c5fef9beef9fceed628db7a10b888f3308b37ae257ad3d50046088317ebf1
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 18974
-  timestamp: 1673491600853
-- platform: linux-64
+  size: 19818
+  timestamp: 1710262791393
+- kind: conda
   name: jupyterlab
-  version: 4.0.8
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.1.5
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+  sha256: b098b79ef34d5c6a9ef7fc482bd2373072820006757ed7db33328af88fb91496
+  md5: 04b1ca9d7ac414b3f5c3fb16066c6861
+  depends:
   - async-lru >=1.0.0
+  - httpx >=0.25.0
   - importlib_metadata >=4.8.3
   - importlib_resources >=1.4
   - ipykernel
@@ -2377,46 +2468,39 @@ package:
   - tomli
   - tornado >=6.2.0
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 299796efa08ad91c602fa4d0c5ecc86f
-    sha256: fe5ca6c8bbda69af332593d7f9592aa19d9ab98d34c647ed0d8fbbae88b29a95
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 5935261
-  timestamp: 1698957039728
-- platform: linux-64
+  size: 7062018
+  timestamp: 1710450498940
+- kind: conda
   name: jupyterlab_pygments
-  version: 0.2.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.3.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
   - pygments >=2.4.1,<3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 243f63592c8e449f40cd42eb5cf32f40
-    sha256: 08453e09d5a6bbaeeca839553a5dfd7a377a97550efab96019c334a8042f54f5
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 17410
-  timestamp: 1649936689608
-- platform: linux-64
+  size: 18776
+  timestamp: 1707149279640
+- kind: conda
   name: jupyterlab_server
-  version: 2.25.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.25.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
+  sha256: d0336d0c0223a66d648b24cfd1512fd7aebc85550d47f55ad5edbd53f482e7e5
+  md5: ffd61670ae09d2d3c637f6afd29db443
+  depends:
   - babel >=2.10
   - importlib-metadata >=4.8.3
   - jinja2 >=3.0.3
@@ -2426,1024 +2510,856 @@ package:
   - packaging >=21.3
   - python >=3.8
   - requests >=2.31
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cf15f8fd42c77af4eb1611fe614df2f
-    sha256: 5f373d9adc11b6d49bee06a4c6bea9623fff1d2a0b798edc2e3f594680aa18f3
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 48817
-  timestamp: 1699455046539
-- platform: linux-64
+  size: 48821
+  timestamp: 1710189875931
+- kind: conda
+  name: kernel-headers_linux-64
+  version: 4.18.0
+  build: he073ed8_1
+  build_number: 1
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_1.conda
+  sha256: acad295b4215490f801bf43a85804f3e73fe3831e9a74dbe00d9efbfab572eea
+  md5: 67a8a5bfdfd73566b6c959f0597c13db
+  depends:
+  - _sysroot_linux-64_curr_repodata_hack 3.*
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 1258993
+  timestamp: 1708000850570
+- kind: conda
   name: keyutils
   version: 1.6.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-  hash:
-    md5: 30186d27e2c9fa62b45fb1476b7200e3
-    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- platform: linux-64
+- kind: conda
   name: kiwisolver
   version: 1.4.5
-  category: main
-  manager: conda
-  dependencies:
+  build: py310hd41b1e2_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+  sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
+  md5: b8d67603d43b23ce7e988a5d81a7ab79
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
-  hash:
-    md5: b8d67603d43b23ce7e988a5d81a7ab79
-    sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
-  build: py310hd41b1e2_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
   size: 73123
   timestamp: 1695380074542
-- platform: linux-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h659d440_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  md5: cd95826dbd331ed1be26bdf401432844
+  depends:
   - keyutils >=1.6.1,<2.0a0
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  hash:
-    md5: cd95826dbd331ed1be26bdf401432844
-    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  build: h659d440_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 1371181
   timestamp: 1692097755782
-- platform: linux-64
+- kind: conda
   name: lame
   version: '3.100'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-  hash:
-    md5: a8832b479f93521a9e7b5b743803be51
-    sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   build: h166bdaf_1003
-  arch: x86_64
-  subdir: linux-64
   build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.0-only
   license_family: LGPL
   size: 508258
   timestamp: 1664996250081
-- platform: linux-64
+- kind: conda
   name: lcms2
-  version: '2.15'
-  category: main
-  manager: conda
-  dependencies:
+  version: '2.16'
+  build: hb7c19ff_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
   - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
-  hash:
-    md5: e96637dd92c5f340215c753a5c9a22d7
-    sha256: cc0b2ddab52b20698b26fe8622ebe37e0d462d8691a1f324e7b00f7d904765e3
-  build: hb7c19ff_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: MIT
   license_family: MIT
-  size: 239723
-  timestamp: 1695969712554
-- platform: linux-64
+  size: 245247
+  timestamp: 1701647787198
+- kind: conda
   name: ld_impl_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
   build: h41732ed_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
   constrains:
   - binutils_impl_linux-64 2.40
   license: GPL-3.0-only
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- platform: linux-64
+- kind: conda
   name: lerc
   version: 4.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-  hash:
-    md5: 76bbff344f0134279f225174e9064c8f
-    sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
-  build: h27087fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
   size: 281798
   timestamp: 1657977462600
-- platform: linux-64
+- kind: conda
   name: libabseil
-  version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
+  version: '20240116.1'
+  build: cxx17_h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+  sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
+  md5: 75648bc5dd3b8eab22406876c24d81ec
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-  hash:
-    md5: 2785ddf4cb0e7e743477991d64353947
-    sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  build: cxx17_h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - abseil-cpp =20230802.1
-  - libabseil-static =20230802.1=cxx17*
+  - libabseil-static =20240116.1=cxx17*
+  - abseil-cpp =20240116.1
   license: Apache-2.0
   license_family: Apache
-  size: 1263396
-  timestamp: 1695063868515
-- platform: linux-64
-  name: libass
-  version: 0.17.1
-  category: main
-  manager: conda
-  dependencies:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=8.1.1,<9.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
-  hash:
-    md5: c306fd9cc90c0585171167d09135a827
-    sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
-  build: h8fe9dca_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: ISC
-  license_family: OTHER
-  size: 126896
-  timestamp: 1693027051367
-- platform: linux-64
+  size: 1266503
+  timestamp: 1709159756788
+- kind: conda
   name: libavif16
-  version: 1.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - aom >=3.6.1,<3.7.0a0
+  version: 1.0.4
+  build: hd9d6309_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.0.4-hd9d6309_2.conda
+  sha256: 0217068a813c301e46b86b9f402774bb3eb5789de9dfa4bdd5d193cd2610131f
+  md5: a8c65cba5f77abc1f2e85ab9a0e614aa
+  depends:
+  - aom >=3.8.2,<3.9.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
   - libgcc-ng >=12
   - rav1e >=0.6.6,<1.0a0
-  - svt-av1 >=1.7.0,<1.7.1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.0.1-h87da1f6_2.conda
-  hash:
-    md5: 0281e5f0887a512d7cc2a843173ca243
-    sha256: 267fa8bc6111598415b1cc35d07fe16a8907a8f3edacd9e1c117b5d73655133a
-  build: h87da1f6_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  - svt-av1 >=2.0.0,<2.0.1.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 95735
-  timestamp: 1696226088455
-- platform: linux-64
+  size: 94259
+  timestamp: 1710443352005
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libopenblas >=0.3.24,<0.3.25.0a0
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
-  hash:
-    md5: 420f4e9be59d0dc9133a0f43f7bab3f3
-    sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
-  build: 19_linux64_openblas
-  arch: x86_64
+  build: 21_linux64_openblas
+  build_number: 21
   subdir: linux-64
-  build_number: 19
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
+  sha256: ebd5c91f029f779fb88a1fcbd1e499559a9c258e3674ff58a2fbb4e375ae56d9
+  md5: 0ac9f44fc096772b0aa092119b00c3ca
+  depends:
+  - libopenblas >=0.3.26,<0.3.27.0a0
+  - libopenblas >=0.3.26,<1.0a0
   constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
   - blas * openblas
-  - libcblas 3.9.0 19_linux64_openblas
-  - liblapack 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
+  - libcblas 3.9.0 21_linux64_openblas
+  - liblapack 3.9.0 21_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14566
-  timestamp: 1697484219912
-- platform: linux-64
+  size: 14691
+  timestamp: 1705979549006
+- kind: conda
   name: libbrotlicommon
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-  hash:
-    md5: aec6c91c7371c26392a06708a73c70e5
-    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
   build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  md5: aec6c91c7371c26392a06708a73c70e5
+  depends:
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
   size: 69403
   timestamp: 1695990007212
-- platform: linux-64
+- kind: conda
   name: libbrotlidec
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  md5: f07002e225d7a60a694d42a7bf5ff53f
+  depends:
   - libbrotlicommon 1.1.0 hd590300_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-  hash:
-    md5: f07002e225d7a60a694d42a7bf5ff53f
-    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
   size: 32775
   timestamp: 1695990022788
-- platform: linux-64
+- kind: conda
   name: libbrotlienc
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  md5: 5fc11c6020d421960607d821310fcd4d
+  depends:
   - libbrotlicommon 1.1.0 hd590300_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-  hash:
-    md5: 5fc11c6020d421960607d821310fcd4d
-    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
   size: 282523
   timestamp: 1695990038302
-- platform: linux-64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 19_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
-  hash:
-    md5: d12374af44575413fbbd4a217d46ea33
-    sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
-  build: 19_linux64_openblas
-  arch: x86_64
+  build: 21_linux64_openblas
+  build_number: 21
   subdir: linux-64
-  build_number: 19
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
+  sha256: 467bbfbfe1a1aeb8b1f9f6485eedd8ed1b6318941bf3702da72336ccf4dc25a6
+  md5: 4a3816d06451c4946e2db26b86472cb6
+  depends:
+  - libblas 3.9.0 21_linux64_openblas
   constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
   - blas * openblas
-  - liblapack 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 21_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14458
-  timestamp: 1697484230827
-- platform: linux-64
+  size: 14614
+  timestamp: 1705979564122
+- kind: conda
   name: libccd-double
   version: '2.1'
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
+  sha256: 4695ce68eda595b4f53146bea1096a9f2e0d33290618ba83a246b5ed8871ebc9
+  md5: 6a3d962d34385e0a511b859d679f6ea2
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
-  hash:
-    md5: 6a3d962d34385e0a511b859d679f6ea2
-    sha256: 4695ce68eda595b4f53146bea1096a9f2e0d33290618ba83a246b5ed8871ebc9
-  build: h59595ed_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   constrains:
   - libccd <1
   license: BSD-3-Clause
   license_family: BSD
   size: 36171
   timestamp: 1687341825064
-- platform: linux-64
+- kind: conda
+  name: libcublas
+  version: 12.4.2.65
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.4.2.65-hd3aeb46_0.conda
+  sha256: 9dedaa2641436e1f6542c930a0ea1f2ce6a9b8972c0213e904e0d01a845757ad
+  md5: a83c33c2abd3bd467e13329a9655cb03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-nvrtc
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 239538975
+  timestamp: 1709680919706
+- kind: conda
+  name: libcufft
+  version: 11.2.0.44
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.2.0.44-hd3aeb46_0.conda
+  sha256: 1832f59bd2599efdee5226d7cd7a684d1a6d250ae2a309c43a7eb4e26e70136c
+  md5: dc9bd2796334ff4779aacccc53221b31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 174984145
+  timestamp: 1709677606989
+- kind: conda
+  name: libcurand
+  version: 10.3.5.119
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.5.119-hd3aeb46_0.conda
+  sha256: 178924252a8b85057ef00cecc1a5986d3d6165fdf7e590c44973fa5a7d145481
+  md5: 5564e2f42abcee7e355ef9ce13a51547
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 41612490
+  timestamp: 1709680256658
+- kind: conda
   name: libcurl
-  version: 8.4.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 8.6.0
+  build: hca28451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.6.0-hca28451_0.conda
+  sha256: 357ce806adf1818dc8dccdcd64627758e1858eb0d8a9c91aae4a0eeee2a44608
+  md5: 704739398d858872cb91610f49f0ef29
+  depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
-  - libnghttp2 >=1.52.0,<2.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
-  hash:
-    md5: 1158ac1d2613b28685644931f11ee807
-    sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
-  build: hca28451_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: curl
   license_family: MIT
-  size: 386160
-  timestamp: 1697009208544
-- platform: linux-64
+  size: 391187
+  timestamp: 1710590979402
+- kind: conda
+  name: libcusolver
+  version: 11.6.0.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.6.0.99-hd3aeb46_0.conda
+  sha256: be3b076d05364460ddb27d9c15244993f5202a8196321a827346fd41e626ba5b
+  md5: ccea7d03d84947a00296f6a39dc774b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libcublas >=12.4.2.65,<12.5.0a0
+  - libcusparse >=12.3.0.142,<12.4.0a0
+  - libgcc-ng >=12
+  - libnvjitlink >=12.4.99,<12.5.0a0
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 81939880
+  timestamp: 1709735019768
+- kind: conda
+  name: libcusparse
+  version: 12.3.0.142
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.3.0.142-hd3aeb46_0.conda
+  sha256: e99278e1e8083a8da72ab474629e477d895f6afb898641ab563dc8b679d95671
+  md5: d72fd369532e32f800ab6447e9cd00ac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libnvjitlink >=12.4.99,<12.5.0a0
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 117817599
+  timestamp: 1709722811121
+- kind: conda
   name: libdeflate
   version: '1.19'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
-  hash:
-    md5: 1635570038840ee3f9c71d22aa5b8b6d
-    sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  md5: 1635570038840ee3f9c71d22aa5b8b6d
+  depends:
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
   size: 67080
   timestamp: 1694922285678
-- platform: linux-64
-  name: libdrm
-  version: 2.4.114
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libpciaccess >=0.17,<0.18.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
-  hash:
-    md5: efb58e80f5d0179a783c4e76c3df3b9c
-    sha256: 9316075084ad66f9f96d31836e83303a8199eec93c12d68661e41c44eed101e3
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 305197
-  timestamp: 1667566354412
-- platform: linux-64
+- kind: conda
   name: libedit
   version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
+  build: he28a2e2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
   - libgcc-ng >=7.5.0
   - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  build: he28a2e2_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: BSD-2-Clause
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- platform: linux-64
+- kind: conda
   name: libev
   version: '4.33'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
-  hash:
-    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
-    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
-  build: h516909a_1
-  arch: x86_64
+  build: hd590300_2
+  build_number: 2
   subdir: linux-64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 106190
-  timestamp: 1598867915
-- platform: linux-64
+  size: 112766
+  timestamp: 1702146165126
+- kind: conda
   name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  build: hcb278e6_1
-  arch: x86_64
+  version: 2.6.2
+  build: h59595ed_0
   subdir: linux-64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  depends:
+  - libgcc-ng >=12
   constrains:
-  - expat 2.5.0.*
+  - expat 2.6.2.*
   license: MIT
   license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
-- platform: linux-64
+  size: 73730
+  timestamp: 1710362120304
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   build: h7f98852_5
-  arch: x86_64
-  subdir: linux-64
   build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- platform: linux-64
+- kind: conda
+  name: libgcc-devel_linux-64
+  version: 12.3.0
+  build: h8bca6fd_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
+  sha256: ed2dfc6d959dc27e7668439e1ad31b127b43e99f9a7e77a2d34b958fa797316b
+  md5: e12ce6b051085b8f27e239f5e5f5bce5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2568967
+  timestamp: 1706819720613
+- kind: conda
   name: libgcc-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h807b86a_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+  sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
+  md5: d4ff227c46917d3b4565302a2bbb276b
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
-  hash:
-    md5: c28003b0be0494f9a7664389146716ff
-    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
-  build: h807b86a_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   constrains:
-  - libgomp 13.2.0 h807b86a_2
+  - libgomp 13.2.0 h807b86a_5
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 771133
-  timestamp: 1695219384393
-- platform: linux-64
+  size: 770506
+  timestamp: 1706819192021
+- kind: conda
   name: libgfortran-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 13.2.0 ha4646dd_2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
-  hash:
-    md5: e75a75a6eaf6f318dae2631158c46575
-    sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
-  build: h69a702a_2
-  arch: x86_64
+  build: h69a702a_5
+  build_number: 5
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
+  sha256: 238c16c84124d58307376715839aa152bd4a1bf5a043052938ad6c3137d30245
+  md5: e73e9cfd1191783392131e6238bdb3e9
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_5
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23722
-  timestamp: 1695219642066
-- platform: linux-64
+  size: 23829
+  timestamp: 1706819413770
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
-  hash:
-    md5: 78fdab09d9138851dde2b5fe2a11019e
-    sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  build: ha4646dd_2
-  arch: x86_64
+  build: ha4646dd_5
+  build_number: 5
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
+  sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
+  md5: 7a6bd7a12a4bd359e2afe6c0fa1acace
+  depends:
+  - libgcc-ng >=13.2.0
   constrains:
   - libgfortran-ng 13.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1441830
-  timestamp: 1695219403435
-- platform: linux-64
-  name: libglib
-  version: 2.78.1
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.40,<10.41.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-hebfc3b9_0.conda
-  hash:
-    md5: ddd09e8904fde46b85f41896621803e6
-    sha256: 44c5f58593b074886436db7d13fdfcba2fe3731867ea52237f049b8400341a2b
-  build: hebfc3b9_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - glib 2.78.1 *_0
-  license: LGPL-2.1-or-later
-  size: 2688566
-  timestamp: 1699278005640
-- platform: linux-64
+  size: 1442769
+  timestamp: 1706819209473
+- kind: conda
   name: libgomp
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - _libgcc_mutex 0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
-  hash:
-    md5: e2042154faafe61969556f28bade94b9
-    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
-  build: h807b86a_2
-  arch: x86_64
+  build: h807b86a_5
+  build_number: 5
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+  sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
+  md5: d211c42b9ce49aee3734fdc828731689
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 421133
-  timestamp: 1695219303065
-- platform: linux-64
+  size: 419751
+  timestamp: 1706819107383
+- kind: conda
   name: libgrpc
-  version: 1.58.2
-  category: main
-  manager: conda
-  dependencies:
-  - c-ares >=1.20.1,<2.0a0
+  version: 1.62.1
+  build: h15f2491_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
+  sha256: 1d4ece94dfef73d904dcba0fd9d56098796f5fdc62ea5f9edff60c71be7a3d63
+  md5: 564517a8cbd095cff75eb996d33d2b7e
+  depends:
+  - c-ares >=1.27.0,<2.0a0
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
-  - libprotobuf >=4.24.3,<4.24.4.0a0
-  - libre2-11 >=2023.6.2,<2024.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libre2-11 >=2023.9.1,<2024.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.58.2-he06187c_0.conda
-  hash:
-    md5: 1eec35ecc7bd34e4ec2f2b4eccb8816e
-    sha256: f910b7f57997fabae045f38d5f16148324536cf6f948a575446d653536d39b78
-  build: he06187c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - grpc-cpp =1.58.2
+  - grpc-cpp =1.62.1
   license: Apache-2.0
   license_family: APACHE
-  size: 6781639
-  timestamp: 1698719086843
-- platform: linux-64
+  size: 7667664
+  timestamp: 1709938059287
+- kind: conda
   name: libiconv
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
-  hash:
-    md5: b62b52da46c39ee2bc3c162ac7f1804d
-    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
-  build: h166bdaf_0
-  arch: x86_64
+  build: hd590300_2
+  build_number: 2
   subdir: linux-64
-  build_number: 0
-  license: GPL and LGPL
-  size: 1450368
-  timestamp: 1652700749886
-- platform: linux-64
-  name: libidn2
-  version: 2.3.4
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
   - libgcc-ng >=12
-  - libunistring >=0,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.4-h166bdaf_0.tar.bz2
-  hash:
-    md5: 7440fbafd870b8bab68f83a064875d34
-    sha256: 888848ae85be9df86f56407639c63bdce8e7651f0b2517be9bc0ac6e38b2d21d
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPLv2
-  size: 160409
-  timestamp: 1666574022481
-- platform: linux-64
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- kind: conda
   name: libjpeg-turbo
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-  hash:
-    md5: ea25936bb4080d843790b586850f82b8
-    sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
   build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
   size: 618575
   timestamp: 1694474974816
-- platform: linux-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 19_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
-  hash:
-    md5: 9f100edf65436e3eabc2a51fc00b2c37
-    sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
-  build: 19_linux64_openblas
-  arch: x86_64
+  build: 21_linux64_openblas
+  build_number: 21
   subdir: linux-64
-  build_number: 19
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
+  sha256: 64b5c35dce00dd6f9f53178b2fe87116282e00967970bd6551a5a42923806ded
+  md5: 1a42f305615c3867684e049e85927531
+  depends:
+  - libblas 3.9.0 21_linux64_openblas
   constrains:
+  - liblapacke 3.9.0 21_linux64_openblas
+  - libcblas 3.9.0 21_linux64_openblas
   - blas * openblas
-  - libcblas 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14487
-  timestamp: 1697484241613
-- platform: linux-64
+  size: 14599
+  timestamp: 1705979579648
+- kind: conda
   name: libmujoco
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.1.3
+  build: hfbbffa6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmujoco-3.1.3-hfbbffa6_1.conda
+  sha256: 28f3671a1d0001f02eb0404dd8882b0144ba9f68fd62f52543b691119b89debe
+  md5: 4cfdda5de8715296eff7c8d07aa4158a
+  depends:
   - libccd-double >=2.1,<2.2.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - lodepng >=20220109,<20220110.0a0
   - qhull >=2020.2,<2020.3.0a0
-  - tinyxml2 >=9.0.0,<10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmujoco-3.0.0-hcd4a4b4_0.conda
-  hash:
-    md5: 3224554fadc73561bda48cd236dd0bd1
-    sha256: a20848a23c546febb2126fc1d96f440c764f77d7cbb08aaadfb03785180c3f3e
-  build: hcd4a4b4_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - tinyxml2 >=10.0.0,<11.0a0
   constrains:
   - mujoco-cxx <0
   license: Apache-2.0
   license_family: APACHE
-  size: 11311323
-  timestamp: 1697739470988
-- platform: linux-64
+  size: 11378105
+  timestamp: 1710193679752
+- kind: conda
   name: libnghttp2
   version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
-  - c-ares >=1.21.0,<2.0a0
+  build: h47da74e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
+  depends:
+  - c-ares >=1.23.0,<2.0a0
   - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
-  hash:
-    md5: 9b13d5ee90fc9f09d54fd403247342b4
-    sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
-  build: h47da74e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
-  size: 631397
-  timestamp: 1699440427647
-- platform: linux-64
+  size: 631936
+  timestamp: 1702130036271
+- kind: conda
   name: libnsl
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  hash:
-    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.1-only
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- platform: linux-64
+- kind: conda
+  name: libnvjitlink
+  version: 12.4.99
+  build: hd3aeb46_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.4.99-hd3aeb46_0.conda
+  sha256: 2de2078a30c67bf1a3601ab22f4b66ab799409d666a48696ca822503a81d12b3
+  md5: 2121026ab1e941622333f4a047d69fa5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.4,<12.5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 16568838
+  timestamp: 1709706434802
+- kind: conda
   name: libopenblas
-  version: 0.3.24
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.3.26
+  build: pthreads_h413a1c8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
+  sha256: b626954b5a1113dafec8df89fa8bf18ce9b4701464d9f084ddd7fc9fac404bbd
+  md5: 760ae35415f5ba8b15d09df5afe8b23a
+  depends:
   - libgcc-ng >=12
   - libgfortran-ng
   - libgfortran5 >=12.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
-  hash:
-    md5: 6e4ef6ca28655124dcde9bd500e44c32
-    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
-  build: pthreads_h413a1c8_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
+  - openblas >=0.3.26,<0.3.27.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5492091
-  timestamp: 1693785223074
-- platform: linux-64
-  name: libopus
-  version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
-  hash:
-    md5: 15345e56d527b330e1cacbdf58676e8f
-    sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
-  build: h7f98852_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 260658
-  timestamp: 1606823578035
-- platform: linux-64
-  name: libpciaccess
-  version: '0.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
-  hash:
-    md5: b7463391cf284065294e2941dd41ab95
-    sha256: 9fe4aaf5629b4848d9407b9ed4da941ba7e5cebada63ee0becb9aa82259dc6e2
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 39750
-  timestamp: 1666091838440
-- platform: linux-64
+  size: 5578031
+  timestamp: 1704950143521
+- kind: conda
   name: libpng
-  version: 1.6.39
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.6.43
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
-  hash:
-    md5: e1c890aebdebbfbf87e2c917187b4416
-    sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
-  build: h753d276_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: zlib-acknowledgement
-  size: 282599
-  timestamp: 1669075729952
-- platform: linux-64
+  size: 288221
+  timestamp: 1708780443939
+- kind: conda
   name: libprotobuf
-  version: 4.24.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.25.3
+  build: h08a7969_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+  sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
+  md5: 6945825cebd2aeb16af4c69d97c32c13
+  depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.3-hf27288f_1.conda
-  hash:
-    md5: 5097789a2bc83e697d7509df57f25bfd
-    sha256: 911ad483f051d96c9f07ecd8177546763c2da601e26941b434c3a09fa9fcd8f8
-  build: hf27288f_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 2667628
-  timestamp: 1697157559259
-- platform: linux-64
+  size: 2811207
+  timestamp: 1709514552541
+- kind: conda
   name: libre2-11
-  version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
+  version: 2023.09.01
+  build: h5a48ba9_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+  sha256: 3f3c65fe0e9e328b4c1ebc2b622727cef3e5b81b18228cfa6cf0955bc1ed8eff
+  md5: 41c69fba59d495e8cf5ffda48a607e35
+  depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
-  hash:
-    md5: c0e7eacd9694db3ef5ef2979a7deea70
-    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
-  build: h7a70373_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - re2 2023.06.02.*
+  - re2 2023.09.01.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 232708
-  timestamp: 1697065825934
-- platform: linux-64
+  size: 232603
+  timestamp: 1708946763521
+- kind: conda
+  name: libsanitizer
+  version: 12.3.0
+  build: h0f45ef3_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
+  sha256: 70329cb8b0604273521cdae63520cb364a8d5477e156e65cdbd810984caeabee
+  md5: 11d1ceacff40054d5a74b12975d76f20
+  depends:
+  - libgcc-ng >=12.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3890717
+  timestamp: 1706819904612
+- kind: conda
   name: libsodium
   version: 1.0.18
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-  hash:
-    md5: c3788462a6fbddafdb413a9f9053e58d
-    sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
   build: h36c2ea0_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
   license: ISC
   size: 374999
   timestamp: 1605135674116
-- platform: linux-64
+- kind: conda
   name: libsqlite
-  version: 3.44.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.45.2
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+  sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
+  md5: 866983a220e27a80cb75e85cb30466a1
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
-  hash:
-    md5: b58e6816d137f3aabf77d341dd5d732b
-    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
-  build: h2797004_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Unlicense
-  size: 845977
-  timestamp: 1698854720770
-- platform: linux-64
+  size: 857489
+  timestamp: 1710254744982
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h0841786_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-  hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  build: h0841786_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- platform: linux-64
-  name: libstdcxx-ng
-  version: 13.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
-  hash:
-    md5: 9172c297304f2a20134fc56c97fbe229
-    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
-  build: h7e041cc_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
+- kind: conda
+  name: libstdcxx-devel_linux-64
+  version: 12.3.0
+  build: h8bca6fd_105
+  build_number: 105
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_105.conda
+  sha256: efcd4b4cba79cd0fb5a87757c7ca63171cf3b7b06446192364bae7defb50b94c
+  md5: b3c6062c84a8e172555ee104ea6a01ab
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3842773
-  timestamp: 1695219454837
-- platform: linux-64
-  name: libtasn1
-  version: 4.19.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
-  hash:
-    md5: 93840744a8552e9ebf6bb1a5dffc125a
-    sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
-  build: h166bdaf_0
-  arch: x86_64
+  size: 11597918
+  timestamp: 1706819775415
+- kind: conda
+  name: libstdcxx-ng
+  version: 13.2.0
+  build: h7e041cc_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
-  license: GPL-3.0-or-later
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
+  sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
+  md5: f6f6600d18a4047b54f803cf708b868a
+  license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 116878
-  timestamp: 1661325701583
-- platform: linux-64
+  size: 3834139
+  timestamp: 1706819252496
+- kind: conda
   name: libtiff
   version: 4.6.0
-  category: main
-  manager: conda
-  dependencies:
+  build: ha9c0a0a_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  md5: 55ed21669b2015f77c180feb1dd41930
+  depends:
   - lerc >=4.0.0,<5.0a0
   - libdeflate >=1.19,<1.20.0a0
   - libgcc-ng >=12
@@ -3453,273 +3369,213 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
-  hash:
-    md5: 55ed21669b2015f77c180feb1dd41930
-    sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
-  build: ha9c0a0a_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: HPND
   size: 283198
   timestamp: 1695661593314
-- platform: linux-64
-  name: libunistring
-  version: 0.9.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
-  hash:
-    md5: 7245a044b4a1980ed83196176b78b73a
-    sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
-  build: h7f98852_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: GPL-3.0-only OR LGPL-3.0-only
-  size: 1433436
-  timestamp: 1626955018689
-- platform: linux-64
+- kind: conda
   name: libuuid
   version: 2.38.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  hash:
-    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   build: h0b41bf4_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
   license: BSD-3-Clause
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- platform: linux-64
-  name: libva
-  version: 2.20.0
-  category: main
-  manager: conda
-  dependencies:
-  - libdrm >=2.4.114,<2.5.0a0
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
-  hash:
-    md5: 933bcea637569c6cea6084957028cb53
-    sha256: 972d6f67d854d0f0fc2593f8bddc8d411859437ace7248c374e1a85a9ea9d410
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 188151
-  timestamp: 1694689905260
-- platform: linux-64
+- kind: conda
   name: libvpx
-  version: 1.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
-  hash:
-    md5: 0974a6d3432e10bae02bcab0cce1b308
-    sha256: 8067e73d6e4f82eae158cb86acdc2d1cf18dd7f13807f0b93e13a07ee4c04b79
-  build: h59595ed_0
-  arch: x86_64
+  version: 1.11.0
+  build: h9c3ff4c_3
+  build_number: 3
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.11.0-h9c3ff4c_3.tar.bz2
+  sha256: e2c2a0bb21db1724af90cab5aa1fb3096db4c11df1ab85178571dcb8395e7a15
+  md5: ebe18273eebadbb4dfb13f1062e054e9
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1006029
-  timestamp: 1696342275863
-- platform: linux-64
+  size: 1146818
+  timestamp: 1635005051234
+- kind: conda
   name: libwebp-base
   version: 1.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-  hash:
-    md5: 30de3fd9b3b602f7473f30e684eeea8c
-    sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
   constrains:
   - libwebp 1.3.2
   license: BSD-3-Clause
   license_family: BSD
   size: 401830
   timestamp: 1694709121323
-- platform: linux-64
+- kind: conda
   name: libxcb
   version: '1.15'
-  category: main
-  manager: conda
-  dependencies:
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  md5: 33277193f5b92bad9fdd230eb700929c
+  depends:
   - libgcc-ng >=12
   - pthread-stubs
   - xorg-libxau
   - xorg-libxdmcp
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
-  hash:
-    md5: 33277193f5b92bad9fdd230eb700929c
-    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
-  build: h0b41bf4_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 384238
   timestamp: 1682082368177
-- platform: linux-64
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- kind: conda
+  name: libxkbcommon
+  version: 1.6.0
+  build: hd429924_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
+  sha256: 213a4c927618198fd5fb5e7b0a76b89310a9c04a3ea025d59771754ee8a89451
+  md5: 1dbcc04604fdf1e526e6d1b0b6938396
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.11,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 574868
+  timestamp: 1701352639132
+- kind: conda
   name: libxml2
-  version: 2.11.5
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.12.5
+  build: h232c23b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+  sha256: db9bf97e9e367985204331b58a059ebd5a4e0cb9e1c8754e9ecb23046b7b7bc1
+  md5: c442ebfda7a475f5e78f1c8e45f1e919
+  depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
-  hash:
-    md5: f3858448893839820d4bcfb14ad3ecdf
-    sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
-  build: h232c23b_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
-  size: 705542
-  timestamp: 1692960341690
-- platform: linux-64
+  size: 704829
+  timestamp: 1707084502281
+- kind: conda
   name: libzlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
   build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
   build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
   constrains:
   - zlib 1.2.13 *_5
   license: Zlib
   license_family: Other
   size: 61588
   timestamp: 1686575217516
-- platform: linux-64
+- kind: conda
   name: lodepng
   version: '20220109'
-  category: main
-  manager: conda
-  dependencies:
+  build: h924138e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lodepng-20220109-h924138e_0.tar.bz2
+  sha256: 31f9bf8dfa2a6f1eb1c47e48e57b7a2b0ef25d0df18741cc3e4abd0fe076bb1d
+  md5: 6d6c59898d7a764ff90bb1147e234056
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lodepng-20220109-h924138e_0.tar.bz2
-  hash:
-    md5: 6d6c59898d7a764ff90bb1147e234056
-    sha256: 31f9bf8dfa2a6f1eb1c47e48e57b7a2b0ef25d0df18741cc3e4abd0fe076bb1d
-  build: h924138e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Zlib
   size: 102103
   timestamp: 1654538581172
-- platform: linux-64
+- kind: conda
   name: lz4-c
   version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
+  build: hcb278e6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-  hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  build: hcb278e6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-2-Clause
   license_family: BSD
   size: 143402
   timestamp: 1674727076728
-- platform: linux-64
+- kind: conda
   name: markdown-it-py
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
   - mdurl >=0.1,<1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 64356
   timestamp: 1686175179621
-- platform: linux-64
+- kind: conda
   name: markupsafe
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.1.5
+  build: py310h2372a71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py310h2372a71_0.conda
+  sha256: 3c18347adf1d091ee9248612308a6bef79038f80b626ef67f58cd0e8d25c65b8
+  md5: f6703fa0214a00bf49d1bef6dc7672d0
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
-  hash:
-    md5: b74e07a054c479e45a83a83fc5be713c
-    sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 24054
-  timestamp: 1695367637074
-- platform: linux-64
+  size: 24493
+  timestamp: 1706900070478
+- kind: conda
   name: matplotlib-base
-  version: 3.8.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.8.3
+  build: py310h62c0568_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py310h62c0568_0.conda
+  sha256: f3179a086a10a0d7561b5935cfa5986ed9d1fd15b86f5a68de813455cd58f98f
+  md5: 4a7296c0273eb01dfbed728dd6a6725a
+  depends:
   - certifi >=2020.06.20
   - contourpy >=1.0.1
   - cycler >=0.10
@@ -3737,238 +3593,193 @@ package:
   - python-dateutil >=2.7
   - python_abi 3.10.* *_cp310
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.1-py310h62c0568_0.conda
-  hash:
-    md5: e650bd952e5618050ccb088bc0c6dfb4
-    sha256: 615197c8b2b816aa1f7874319bd41acb134fcb9cd55e7337563295c8ced0a30e
-  build: py310h62c0568_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 6976980
-  timestamp: 1698868750483
-- platform: linux-64
+  size: 7039849
+  timestamp: 1708026648616
+- kind: conda
   name: matplotlib-inline
   version: 0.1.6
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
   - python >=3.6
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 12273
   timestamp: 1660814913405
-- platform: linux-64
+- kind: conda
   name: mdurl
-  version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  version: 0.1.2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  md5: 776a8dd9e824f77abac30e6ef43a8f7a
+  depends:
+  - python >=3.6
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 13707
-  timestamp: 1639515992326
-- platform: linux-64
+  size: 14680
+  timestamp: 1704317789138
+- kind: conda
   name: mediapy
-  version: 1.1.9
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.2.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mediapy-1.2.0-pyhd8ed1ab_0.conda
+  sha256: 58490f8e5a7638576cafe17971dddf55cb8f95b601076c3e0796e408b0aaf58d
+  md5: 8ebe9143bba8b25695779dccf75d98e4
+  depends:
   - ffmpeg
   - ipython
   - matplotlib-base
   - numpy
   - pillow
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mediapy-1.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: e9e558a8619be05e415d280d3405ca41
-    sha256: 27ad896c72b7c4fcfbc2c904b16fff3568bbfdea46c962255b1ec516df387edf
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 29590
-  timestamp: 1691436843123
-- platform: linux-64
+  size: 29678
+  timestamp: 1701860819318
+- kind: conda
   name: mistune
   version: 3.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  md5: 5cbee699846772cc939bef23a0d524ed
+  depends:
+  - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 66022
   timestamp: 1698947249750
-- platform: linux-64
+- kind: conda
   name: ml-collections
   version: 0.1.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ml-collections-0.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 017ce04cd1f456e8a8bfe8768ba6edf59bf2a905a4c384d7d624a153641553a6
+  md5: 678522de10f2352cb732eb67d508bd22
+  depends:
   - absl-py
   - contextlib2
   - python >=3.7
   - pyyaml
   - six
-  url: https://conda.anaconda.org/conda-forge/noarch/ml-collections-0.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 678522de10f2352cb732eb67d508bd22
-    sha256: 017ce04cd1f456e8a8bfe8768ba6edf59bf2a905a4c384d7d624a153641553a6
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 66839
   timestamp: 1664451756771
-- platform: linux-64
+- kind: conda
   name: ml_dtypes
-  version: 0.3.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.3.2
+  build: py310hcc13569_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.3.2-py310hcc13569_0.conda
+  sha256: b8d490515e31049fb3408c60cb4cdf6dc445f4bc2377033a827dbf68463d2085
+  md5: 1ad84020b1ab816d7ab3f3d0859faf40
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.22.4,<2.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.3.1-py310hcc13569_2.conda
-  hash:
-    md5: 6aaa5fa2ba8985779f5e0e4c653bdded
-    sha256: bdac67831707b3b42f8c48bcd1d65ef6d34e3ae9263a7d7b72c0be80e0070d7c
-  build: py310hcc13569_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: MPL-2.0 AND Apache-2.0
-  size: 161055
-  timestamp: 1697644326557
-- platform: linux-64
+  size: 164312
+  timestamp: 1704727828371
+- kind: conda
   name: msgpack-python
-  version: 1.0.6
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.0.7
+  build: py310hd41b1e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.7-py310hd41b1e2_0.conda
+  sha256: a5c7612029e3871b0af0bd69e8ee1545d3deb93b5bec29cf1bf72522375fda31
+  md5: dc5263dcaa1347e5a456ead3537be27d
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py310hd41b1e2_0.conda
-  hash:
-    md5: 03255e1437f31f25ad95bb45c8b398bb
-    sha256: cf37ee99132533005db95b611377d99f3cf4cb6feed494806d53aa7101768cd4
-  build: py310hd41b1e2_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 197088
-  timestamp: 1695464250291
-- platform: linux-64
+  size: 196895
+  timestamp: 1700926652044
+- kind: conda
   name: mujoco
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libmujoco 3.0.0 hcd4a4b4_0
-  - mujoco-python >=3.0.0,<3.0.1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-3.0.0-ha770c72_0.conda
-  hash:
-    md5: fd61773e9bab4d33cb99ca7b92f492f6
-    sha256: 7808411d99cee9536b87aa5ec89a710b16d4a82a9cc4b3c9723dcda3bb92a1c9
-  build: ha770c72_0
-  arch: x86_64
+  version: 3.1.3
+  build: ha770c72_1
+  build_number: 1
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-3.1.3-ha770c72_1.conda
+  sha256: 87deb092e6e744322ded0631cbeb8d47c51a3810e1c9e6db5d0317da0e259bf9
+  md5: 6bcaa21b5693e3edae89e6281a51a99e
+  depends:
+  - libmujoco 3.1.3 hfbbffa6_1
+  - mujoco-python >=3.1.3,<3.1.4.0a0
+  - mujoco-samples 3.1.3 h59595ed_1
+  - mujoco-simulate 3.1.3 h59595ed_1
   license: Apache-2.0
   license_family: APACHE
-  size: 17605
-  timestamp: 1697739783768
-- platform: linux-64
+  size: 19997
+  timestamp: 1710194000515
+- kind: conda
   name: mujoco-mjx
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.1.3
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mujoco-mjx-3.1.3-pyhd8ed1ab_1.conda
+  sha256: 4e9f020887c83752da00b71eee33f701008a01bf9c7ed012be81f2d8dc0af6cb
+  md5: 8093c8920e03a01aeec2ef9ec0b9ed8b
+  depends:
   - absl-py
   - etils
   - fsspec
   - importlib_resources
   - jax >=0.4.13
   - jaxlib >=0.4.13
-  - mujoco-python >=3.0.0
+  - mujoco-python >=3.1.3
   - python
   - scipy
   - trimesh
   - typing_extensions
   - zipp
-  url: https://conda.anaconda.org/conda-forge/noarch/mujoco-mjx-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 73dbec56fc1a21d619d8b17e3141ed40
-    sha256: f392e735fecb5bec748fc6cc56ec24240d5a5a8b6d86592e90787ae6158f009b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 3681304
-  timestamp: 1697740781957
-- platform: linux-64
+  size: 5482470
+  timestamp: 1710195437299
+- kind: conda
   name: mujoco-python
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.1.3
+  build: py310hb9d608c_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-python-3.1.3-py310hb9d608c_1.conda
+  sha256: 7f12150bd085ee2dd56d18ef3dd138603d47e5c34a53418769bab408e0d97167
+  md5: aac8f367913dd224f8242c517407e458
+  depends:
   - absl-py
   - etils
   - fsspec
-  - glfw >=3.3.8,<4.0a0
+  - glfw >=3.4,<4.0a0
   - importlib_resources
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
-  - libmujoco 3.0.0 hcd4a4b4_0
+  - libmujoco 3.1.3 hfbbffa6_1
   - libstdcxx-ng >=12
   - lodepng >=20220109,<20220110.0a0
   - numpy >=1.22.4,<2.0a0
@@ -3979,68 +3790,90 @@ package:
   - python_abi 3.10.* *_cp310
   - typing_extensions
   - zipp
-  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-python-3.0.0-py310h7293d3f_0.conda
-  hash:
-    md5: aef6652336e05e62f07fe5832f9b6ed2
-    sha256: f0ab70a201aaa9f280b2f54b5c739c94a5b5f8d136e2ec81939cf3a66418c65e
-  build: py310h7293d3f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 1427354
-  timestamp: 1697740281919
-- platform: linux-64
+  size: 1447249
+  timestamp: 1710195308274
+- kind: conda
+  name: mujoco-samples
+  version: 3.1.3
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-samples-3.1.3-h59595ed_1.conda
+  sha256: 819ac951fdbad34a4c72bb0af1e7f7b959da99e0be63cb59b512c17106be8ab6
+  md5: a808fa342a5e7a0b52610fa436b7f715
+  depends:
+  - glfw >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libmujoco >=3.1.3,<3.1.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 36885
+  timestamp: 1710193968960
+- kind: conda
+  name: mujoco-simulate
+  version: 3.1.3
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-simulate-3.1.3-h59595ed_1.conda
+  sha256: 8b1fd61eded5cfb8b358992b5a5ae474741003c7187aa3fa2f4f299089fa1fd4
+  md5: 8bb424ecb23e20109aca029470d65c8d
+  depends:
+  - glfw >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libmujoco >=3.1.3,<3.1.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 73689
+  timestamp: 1710193996774
+- kind: conda
   name: munkres
   version: 1.1.4
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   build: pyh9f0ad1d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 12452
   timestamp: 1600387789153
-- platform: linux-64
+- kind: conda
   name: nbclient
-  version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.10.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
+  md5: 15b51397e0fe8ea7d7da60d83eb76ebc
+  depends:
   - jupyter_client >=6.1.12
   - jupyter_core >=4.12,!=5.0.*
   - nbformat >=5.1
   - python >=3.8
   - traitlets >=5.4
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e78da91cf428faaf05701ce8cc8f2f9b
-    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 64852
-  timestamp: 1684791049212
-- platform: linux-64
+  size: 27851
+  timestamp: 1710317767117
+- kind: conda
   name: nbconvert-core
-  version: 7.11.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 7.16.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.2-pyhd8ed1ab_0.conda
+  sha256: e1fe894114763addc98ef147a78fcd9a518bf97d268394c356b80c572c78c82f
+  md5: 5ab3248dd05c543dc631276455ef6a54
+  depends:
   - beautifulsoup4
   - bleach
   - defusedxml
@@ -4058,176 +3891,136 @@ package:
   - python >=3.8
   - tinycss2
   - traitlets >=5.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d59e0cb1ca993f8f910cfdf393232acf
-    sha256: 81732e083c4c85a52248e20ff0e40a14b0b49db9cc7ce414e8aa7d6f8980dad0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - pandoc >=2.14.2,<4.0.0
-  - nbconvert =7.11.0=*_0
+  - nbconvert =7.16.2=*_0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 187582
-  timestamp: 1699286152060
-- platform: linux-64
+  size: 188317
+  timestamp: 1709581437093
+- kind: conda
   name: nbformat
-  version: 5.9.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 5.10.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+  sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
+  md5: ca3d437c0ef2e87f63d085822c74c49a
+  depends:
   - jsonschema >=2.6
   - jupyter_core
   - python >=3.8
   - python-fastjsonschema
   - traitlets >=5.1
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 61ba076de6530d9301a0053b02f093d2
-    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 100446
-  timestamp: 1690815009867
-- platform: linux-64
+  size: 100844
+  timestamp: 1710502340495
+- kind: conda
   name: nccl
-  version: 2.19.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - cuda-version >=11.8,<12.0a0
+  version: 2.20.5.1
+  build: h3a97aeb_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.20.5.1-h3a97aeb_0.conda
+  sha256: 49379e9a04cfda3d21bf28bc868863c16c273253d5cd53881b7f6b1f83903c43
+  md5: 80cf6f5c4b068e1133aec8101efa1767
+  depends:
+  - cuda-version >=12.0,<13
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.19.3.1-h6103f9b_0.conda
-  hash:
-    md5: 5b4426d8e0534cd844924728d2137666
-    sha256: 0464f985f4e1ab8ccbb4b3d169ece570a3ac6e6302d87e1da7b0ef35bc196249
-  build: h6103f9b_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 118236707
-  timestamp: 1696335963125
-- platform: linux-64
+  size: 109011811
+  timestamp: 1709815003844
+- kind: conda
   name: ncurses
   version: '6.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
   build: h59595ed_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
   size: 884434
   timestamp: 1698751260967
-- platform: linux-64
+- kind: conda
   name: nest-asyncio
-  version: 1.5.8
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: a4f0e4519bc50eee4f53f689be9607f7
-    sha256: d7b795b4e754136841c6da3f9fa1a0f7ec37bc7167e7dd68c5b45e657133e008
+  version: 1.6.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
-  size: 11630
-  timestamp: 1697083896431
-- platform: linux-64
+  size: 11638
+  timestamp: 1705850780510
+- kind: conda
   name: nettle
-  version: 3.8.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.8.1-hc379101_1.tar.bz2
-  hash:
-    md5: 3cb2c7df59990bd37c2ce27fd906de68
-    sha256: 49c569a69608eee784e815179a70c6ae4d088dac42b7df999044f68058d593bb
-  build: hc379101_1
-  arch: x86_64
+  version: '3.6'
+  build: he412f7d_0
   subdir: linux-64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+  sha256: d929f0c53f2bb74c8e3d97dc1c53cc76b7cec97837fcf87998fa3dd447f03b36
+  md5: f050099af540c1c960c813b06bca89ad
+  depends:
+  - libgcc-ng >=7.5.0
   license: GPL 2 and LGPL3
   license_family: GPL
-  size: 1195508
-  timestamp: 1659085101126
-- platform: linux-64
+  size: 6773272
+  timestamp: 1605211080998
+- kind: conda
   name: notebook
-  version: 7.0.6
-  category: main
-  manager: conda
-  dependencies:
+  version: 7.1.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.2-pyhd8ed1ab_0.conda
+  sha256: ed5987efcf3a394c4ab12288b4fe7d858784aabc591cebf3dabcd1cdbc7b7347
+  md5: fa781da51f05c9211b75b5e7bcff8136
+  depends:
   - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.0.7,<5
+  - jupyterlab >=4.1.1,<4.2
   - jupyterlab_server >=2.22.1,<3
   - notebook-shim >=0.2,<0.3
   - python >=3.8
   - tornado >=6.2.0
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: d60881c78a54cbf8042ae719f1f77a50
-    sha256: 5259ad2fb47300407dafa6ea5e78085a2c8de8dcdbfbaa58592bf2677d7187a9
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 3122185
-  timestamp: 1697550916556
-- platform: linux-64
+  size: 4091131
+  timestamp: 1710504443849
+- kind: conda
   name: notebook-shim
-  version: 0.2.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.2.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
   - jupyter_server >=1.8,<3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67e0fe74c156267d9159e9133df7fd37
-    sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 16783
-  timestamp: 1682360712235
-- platform: linux-64
+  size: 16880
+  timestamp: 1707957948029
+- kind: conda
   name: numpy
-  version: 1.26.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.26.4
+  build: py310hb13e2d6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
+  sha256: 028fe2ea8e915a0a032b75165f11747770326f3d767e642880540c60a3256425
+  md5: 6593de64c935768b6bad3e19b3e978be
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
@@ -4235,132 +4028,106 @@ package:
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py310hb13e2d6_0.conda
-  hash:
-    md5: ac3b67e928cc71548efad9b522d42fef
-    sha256: d4671e365c2ed30bf8a376bdc65afcbeeae440ca2091c8712ff8f23678f64973
-  build: py310hb13e2d6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6893487
-  timestamp: 1695291234099
-- platform: linux-64
+  size: 7009070
+  timestamp: 1707225917496
+- kind: conda
   name: openh264
-  version: 2.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
-  hash:
-    md5: 37d01894f256b2a6921c5a218f42f8a2
-    sha256: 3be6de15d40f02c9bb34d5095c65b6b3f07e04fc21a0fb63d1885f1a31de5ae2
-  build: hcb278e6_2
-  arch: x86_64
+  version: 2.1.1
+  build: h780b84a_0
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+  sha256: 2ce3df1edb23541595443c7697e5568ae6426fa4d365dede45b16b0310bd6a06
+  md5: 034a6f90f1bbc7ba11d04b84ec9d74c8
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 718775
-  timestamp: 1675880590512
-- platform: linux-64
+  size: 1585354
+  timestamp: 1609583081716
+- kind: conda
   name: openjpeg
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.5.2
+  build: h488ebb8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
   - libgcc-ng >=12
-  - libpng >=1.6.39,<1.7.0a0
+  - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
-  hash:
-    md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
-    sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
-  build: h488ebb8_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: BSD-2-Clause
   license_family: BSD
-  size: 356698
-  timestamp: 1694708325417
-- platform: linux-64
+  size: 341592
+  timestamp: 1709159244431
+- kind: conda
   name: openssl
-  version: 3.1.4
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.2.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+  sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+  md5: 51a753e64a3027bd7e23a189b1f6e91e
+  depends:
   - ca-certificates
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
-  hash:
-    md5: 412ba6938c3e2abaca8b1129ea82e238
-    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2648006
-  timestamp: 1698164814626
-- platform: linux-64
+  size: 2863069
+  timestamp: 1706635653339
+- kind: conda
   name: opt-einsum
   version: 3.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - opt_einsum >=3.3.0,<3.3.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/opt-einsum-3.3.0-hd8ed1ab_2.conda
-  hash:
-    md5: ab262acd95cb73f3ed9426cc4204ac3a
-    sha256: 7cc87658f3ef09bd6f85afdf6c55db0c274960132de4050328759e8b3784df22
   build: hd8ed1ab_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/opt-einsum-3.3.0-hd8ed1ab_2.conda
+  sha256: 7cc87658f3ef09bd6f85afdf6c55db0c274960132de4050328759e8b3784df22
+  md5: ab262acd95cb73f3ed9426cc4204ac3a
+  depends:
+  - opt_einsum >=3.3.0,<3.3.1.0a0
   license: MIT
   license_family: MIT
-  noarch: generic
   size: 6594
   timestamp: 1696449067022
-- platform: linux-64
+- kind: conda
   name: opt_einsum
   version: 3.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhc1e730c_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.3.0-pyhc1e730c_2.conda
+  sha256: 1995657f10e23dbe534219f754c66b7fb2a805d68a3385abdacb7807a915b0c3
+  md5: 7a94ac68b892daa9f17ae8a52b31ed81
+  depends:
   - numpy
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.3.0-pyhc1e730c_2.conda
-  hash:
-    md5: 7a94ac68b892daa9f17ae8a52b31ed81
-    sha256: 1995657f10e23dbe534219f754c66b7fb2a805d68a3385abdacb7807a915b0c3
-  build: pyhc1e730c_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: MIT
   license_family: MIT
-  noarch: python
   size: 58004
   timestamp: 1696449058916
-- platform: linux-64
+- kind: conda
   name: optax
-  version: 0.1.7
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.2.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/optax-0.2.1-pyhd8ed1ab_0.conda
+  sha256: 39847e759ab72e2b310177be5e8765873418701419a9889975d948d52009db51
+  md5: fbf219aec3b26fd88f6b8f5d163d97aa
+  depends:
   - absl-py >=0.7.1
   - chex >=0.1.5
   - jax >=0.1.55
@@ -4368,25 +4135,20 @@ package:
   - numpy >=1.18.0
   - python >=3.8
   - typing_extensions >=3.10
-  url: https://conda.anaconda.org/conda-forge/noarch/optax-0.1.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: ad1f592ff0f2db1d4e17c92ffa7d2141
-    sha256: f4d17d1113388cc1f7804e5d12324dc24ac303d53a1c41e45f89bc727b4a6bfa
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 107820
-  timestamp: 1690808884414
-- platform: linux-64
+  size: 135496
+  timestamp: 1709842520623
+- kind: conda
   name: orbax-checkpoint
-  version: 0.4.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.4.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.4.4-pyhd8ed1ab_0.conda
+  sha256: 79012b755ed91777ed50d60ed790bf9cc5abff7bf05be807331cf15535618d1b
+  md5: 1f3efaebaa9f6e6b6af781bcb60718be
+  depends:
   - absl-py
   - etils
   - importlib_resources
@@ -4400,190 +4162,113 @@ package:
   - pyyaml
   - tensorstore >=0.1.35
   - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/orbax-checkpoint-0.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 851927882e7cd1124410ff524ca6163f
-    sha256: bd5e0c17e840cccf09de4f55abffc2d783ae7bc5fd115de2d5778e2f99f9516d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 83943
-  timestamp: 1699096994570
-- platform: linux-64
+  size: 86896
+  timestamp: 1701452697513
+- kind: conda
   name: overrides
-  version: 7.4.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 7.7.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
   - python >=3.6
   - typing_utils
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4625b7b01d7f4ac9c96300a5515acfaa
-    sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 29976
-  timestamp: 1691338962381
-- platform: linux-64
-  name: p11-kit
-  version: 0.24.1
-  category: main
-  manager: conda
-  dependencies:
-  - libffi >=3.4.2,<3.5.0a0
-  - libgcc-ng >=12
-  - libtasn1 >=4.18.0,<5.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-  hash:
-    md5: 56ee94e34b71742bbdfa832c974e47a8
-    sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
-  build: hc5aa10d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 4702497
-  timestamp: 1654868759643
-- platform: linux-64
+  size: 30232
+  timestamp: 1706394723472
+- kind: conda
   name: packaging
-  version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  version: '24.0'
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
+  sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
+  md5: 248f521b64ce055e7feae3105e7abeb8
+  depends:
+  - python >=3.8
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 49452
-  timestamp: 1696202521121
-- platform: linux-64
+  size: 49832
+  timestamp: 1710076089469
+- kind: conda
   name: pandocfilters
   version: 1.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - python !=3.0,!=3.1,!=3.2,!=3.3
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 457c2c8c08e54905d6954e79cb5b5db9
-    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 11627
   timestamp: 1631603397334
-- platform: linux-64
+- kind: conda
   name: parso
   version: 0.8.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
   license: MIT
   license_family: MIT
-  noarch: python
   size: 71048
   timestamp: 1638335054552
-- platform: linux-64
-  name: pcre2
-  version: '10.40'
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.12,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
-  hash:
-    md5: 69e2c796349cd9b273890bee0febfe1b
-    sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
-  build: hc3806b6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2412495
-  timestamp: 1665562915343
-- platform: linux-64
+- kind: conda
   name: pexpect
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - ptyprocess >=0.5
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
-  hash:
-    md5: 330448ce4403cc74990ac07c555942a1
-    sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-  build: pyh1a96a4e_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: ISC
+  version: 4.9.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
   noarch: python
-  size: 48780
-  timestamp: 1667297617062
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- kind: conda
   name: pickleshare
   version: 0.7.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
   build: py_1003
-  arch: x86_64
-  subdir: linux-64
   build_number: 1003
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
   license: MIT
   license_family: MIT
-  noarch: python
   size: 9332
   timestamp: 1602536313357
-- platform: linux-64
+- kind: conda
   name: pillow
-  version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 10.2.0
+  build: py310h01dd4db_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.2.0-py310h01dd4db_0.conda
+  sha256: ddb300d69329606a9933717127880c2062e9d6539d8824b21a43ed63eb7dab4f
+  md5: 9ec32d0d90f7670eb29bbba18299cf29
+  depends:
   - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.15,<3.0a0
+  - lcms2 >=2.16,<3.0a0
   - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
@@ -4594,825 +4279,612 @@ package:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py310h01dd4db_0.conda
-  hash:
-    md5: 95d87a906d88b5824d7d36eeef091dba
-    sha256: dfc6b069006bd1c8dea5ad33f75ead2615ca3eb8255200c31dfa78db435017ef
-  build: py310h01dd4db_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: HPND
-  size: 46747967
-  timestamp: 1697423797111
-- platform: linux-64
+  size: 41213026
+  timestamp: 1704252199774
+- kind: conda
   name: pip
-  version: 23.3.1
-  category: main
-  manager: conda
-  dependencies:
+  version: '24.0'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+  md5: f586ac1e56c8638b64f9c8122a7b8a67
+  depends:
   - python >=3.7
   - setuptools
   - wheel
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 1398838
-  timestamp: 1697896918388
-- platform: linux-64
-  name: pixman
-  version: 0.42.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
-  hash:
-    md5: 700edd63ccd5fc66b70b1c028cea9a68
-    sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 385309
-  timestamp: 1695736061006
-- platform: linux-64
+  size: 1398245
+  timestamp: 1706960660581
+- kind: conda
   name: pkgutil-resolve-name
   version: 1.3.10
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
-  license: MIT AND PSF-2.0
+  subdir: noarch
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
   size: 10778
   timestamp: 1694617398467
-- platform: linux-64
+- kind: conda
   name: platformdirs
-  version: 3.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - typing-extensions >=4.6.3
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  version: 4.2.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
+  md5: a0bc3eec34b0fab84be6b2da94e98e20
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 19985
-  timestamp: 1696272419779
-- platform: linux-64
+  size: 20210
+  timestamp: 1706713564353
+- kind: conda
   name: prometheus_client
-  version: 0.18.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ade903cbe0b4440ca6bed64932d124b5
-    sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
+  version: 0.20.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+  sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
+  md5: 9a19b94034dd3abb2b348c8b93388035
+  depends:
+  - python >=3.8
   license: Apache-2.0
   license_family: Apache
-  noarch: python
-  size: 53959
-  timestamp: 1698692692135
-- platform: linux-64
+  size: 48913
+  timestamp: 1707932844383
+- kind: conda
   name: prompt-toolkit
-  version: 3.0.39
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.0.42
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
+  sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
+  md5: 0bf64bf10eee21f46ac83c161917fa86
+  depends:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
-  hash:
-    md5: a4986c6bb5b0d05a38855b0880a5f425
-    sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - prompt_toolkit 3.0.39
+  - prompt_toolkit 3.0.42
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 269068
-  timestamp: 1688566090973
-- platform: linux-64
-  name: prompt_toolkit
-  version: 3.0.39
-  category: main
-  manager: conda
-  dependencies:
-  - prompt-toolkit >=3.0.39,<3.0.40.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
-  hash:
-    md5: 4bbbe67d5df19db30f04b8e344dc9976
-    sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
-  build: hd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 6731
-  timestamp: 1688566099039
-- platform: linux-64
+  size: 270398
+  timestamp: 1702399557137
+- kind: conda
   name: protobuf
-  version: 4.24.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.25.3
+  build: py310ha8c1f0e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py310ha8c1f0e_0.conda
+  sha256: 2da5aa342456c2f6a80ebfef9a2a8c57723e8f6c9b00a874660e49a937e8ed9b
+  md5: 0cee4d21cd822c598cf894d1df1657d4
+  depends:
   - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
+  - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
-  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.24.3-py310h620c231_1.conda
-  hash:
-    md5: 84e155f74266d5681f8ab96bca5f1906
-    sha256: cb801f44a8728606faf40484a6110efeea5bf268f201257a6437aa82d997dc15
-  build: py310h620c231_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 329849
-  timestamp: 1696819971866
-- platform: linux-64
+  size: 332424
+  timestamp: 1709685969897
+- kind: conda
   name: psutil
-  version: 5.9.5
-  category: main
-  manager: conda
-  dependencies:
+  version: 5.9.8
+  build: py310h2372a71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py310h2372a71_0.conda
+  sha256: f1866425aa67f3fe1e3f6e07562a4bc986fd487e01146a91eb1bdbe5ec16a836
+  md5: bd19b3096442ea342c4a5208379660b1
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
-  hash:
-    md5: cb25177acf28cc35cfa6c1ac1c679e22
-    sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 361313
-  timestamp: 1695367285835
-- platform: linux-64
+  size: 368328
+  timestamp: 1705722544490
+- kind: conda
   name: pthread-stubs
   version: '0.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
-  hash:
-    md5: 22dad4df6e8630e8dff2428f6f6a7036
-    sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
   build: h36c2ea0_1001
-  arch: x86_64
-  subdir: linux-64
   build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
   license: MIT
   license_family: MIT
   size: 5625
   timestamp: 1606147468727
-- platform: linux-64
+- kind: conda
   name: ptyprocess
   version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
   build: pyhd3deb0d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
+  subdir: noarch
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
   size: 16546
   timestamp: 1609419417991
-- platform: linux-64
+- kind: conda
   name: pure_eval
   version: 0.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
   license: MIT
   license_family: MIT
-  noarch: python
   size: 14551
   timestamp: 1642876055775
-- platform: linux-64
+- kind: conda
   name: pybind11-abi
   version: '4'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
-  hash:
-    md5: 878f923dd6acc8aeb47a75da6c4098be
-    sha256: d4fb485b79b11042a16dc6abfb0c44c4f557707c2653ac47c81e5d32b24a3bb0
   build: hd8ed1ab_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+  sha256: d4fb485b79b11042a16dc6abfb0c44c4f557707c2653ac47c81e5d32b24a3bb0
+  md5: 878f923dd6acc8aeb47a75da6c4098be
   license: BSD-3-Clause
   license_family: BSD
-  noarch: generic
   size: 9906
   timestamp: 1610372835205
-- platform: linux-64
+- kind: conda
   name: pycparser
   version: '2.21'
-  category: main
-  manager: conda
-  dependencies:
-  - python ==2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 102747
   timestamp: 1636257201998
-- platform: linux-64
+- kind: conda
   name: pyglfw
-  version: 2.6.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.7.0
+  build: py310hff52083_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyglfw-2.7.0-py310hff52083_0.conda
+  sha256: c583d4ed81ad71638f1cc4647b5625945d36aef7e2292098172eecad3803f0c4
+  md5: c15a1a5a232c24c4c341143a98ec4a20
+  depends:
   - glfw
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyglfw-2.6.2-py310hff52083_1.conda
-  hash:
-    md5: 1dc8c24db2d1ce22dfa929207391196b
-    sha256: 862425ee42511eb042cdb5263dfe856debd38cbe5f1cfe17c6bc76c5bf9c79f9
-  build: py310hff52083_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
-  size: 57994
-  timestamp: 1695451339501
-- platform: linux-64
+  size: 58044
+  timestamp: 1708777000846
+- kind: conda
   name: pygments
-  version: 2.16.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 40e5cb18165466773619e5c963f00a7b
-    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  version: 2.17.2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+  sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
+  md5: 140a7f159396547e9799aa98f9f0742e
+  depends:
+  - python >=3.7
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
-  size: 853439
-  timestamp: 1691408777841
-- platform: linux-64
+  size: 860425
+  timestamp: 1700608076927
+- kind: conda
   name: pyopengl
   version: 3.1.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c968eb974b0fae4676e7a7858c4cc56e
-    sha256: 4ef77f5227e198b20c1498706fa6b3eb3a32f1cef641b8039d55b7df12e54863
   build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
-  license: LicenseRef-pyopengl
+  subdir: noarch
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
+  sha256: 4ef77f5227e198b20c1498706fa6b3eb3a32f1cef641b8039d55b7df12e54863
+  md5: c968eb974b0fae4676e7a7858c4cc56e
+  depends:
+  - python >=2.7
+  license: LicenseRef-pyopengl
   size: 887829
   timestamp: 1652285640360
-- platform: linux-64
+- kind: conda
   name: pyparsing
-  version: 3.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  version: 3.1.2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+  sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+  md5: b9a4dacf97241704529131a0dfc0494f
+  depends:
+  - python >=3.6
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 89521
-  timestamp: 1690737983548
-- platform: linux-64
+  size: 89455
+  timestamp: 1709721146886
+- kind: conda
   name: pysocks
   version: 1.7.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyha2e5f31_6
+  build_number: 6
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
   - __unix
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-  hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-  build: pyha2e5f31_6
-  arch: x86_64
-  subdir: linux-64
-  build_number: 6
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 18981
   timestamp: 1661604969727
-- platform: linux-64
+- kind: conda
   name: python
   version: 3.10.13
-  category: main
-  manager: conda
-  dependencies:
+  build: hd12c33a_1_cpython
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_1_cpython.conda
+  sha256: 4234c8e301737aa245d12c8fb44a4128005795e42883977c29cca3f34c71a1eb
+  md5: ed38140af93f81319ebc472fbcf16cca
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.43.2,<4.0a0
+  - libsqlite >=3.44.2,<4.0a0
   - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
-  hash:
-    md5: f3a8c32aa764c3e7188b4b810fc9d6ce
-    sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
-  build: hd12c33a_0_cpython
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
-  size: 25476977
-  timestamp: 1698344640413
-- platform: linux-64
+  size: 25670919
+  timestamp: 1703347014418
+- kind: conda
   name: python-dateutil
-  version: 2.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - six >=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  version: 2.9.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+  md5: 2cf4264fffb9e6eff6031c5b6884d61c
+  depends:
+  - python >=3.7
+  - six >=1.5
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 245987
-  timestamp: 1626286448716
-- platform: linux-64
+  size: 222742
+  timestamp: 1709299922152
+- kind: conda
   name: python-fastjsonschema
-  version: 2.18.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.3
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 305141cff54af2f90e089d868fffce28
-    sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
+  version: 2.19.1
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+  sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
+  md5: 4d3ceee3af4b0f9a1f48f57176bf8625
+  depends:
+  - python >=3.3
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 226030
-  timestamp: 1696171963080
-- platform: linux-64
+  size: 225250
+  timestamp: 1703781171097
+- kind: conda
   name: python-json-logger
   version: 2.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: a61bf9ec79426938ff785eb69dbb1960
-    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 13383
   timestamp: 1677079727691
-- platform: linux-64
+- kind: conda
   name: python_abi
   version: '3.10'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
-  hash:
-    md5: 26322ec5d7712c3ded99dd656142b8ce
-    sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
   build: 4_cp310
-  arch: x86_64
-  subdir: linux-64
   build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+  sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
+  md5: 26322ec5d7712c3ded99dd656142b8ce
   constrains:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   size: 6398
   timestamp: 1695147363189
-- platform: linux-64
+- kind: conda
   name: pytinyrenderer
   version: 0.0.13
-  category: main
-  manager: conda
-  dependencies:
+  build: py310he0c9aae_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytinyrenderer-0.0.13-py310he0c9aae_2.conda
+  sha256: fd6163bf9931822195d0446170e272fbb381557b36009656811fc4a47a962669
+  md5: c0884685c44d4fc4c1d1413b1e5eeabc
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.22.4,<2.0a0
   - pybind11-abi 4
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytinyrenderer-0.0.13-py310he0c9aae_2.conda
-  hash:
-    md5: c0884685c44d4fc4c1d1413b1e5eeabc
-    sha256: fd6163bf9931822195d0446170e272fbb381557b36009656811fc4a47a962669
-  build: py310he0c9aae_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: Zlib AND Apache-2.0
   size: 133711
   timestamp: 1696706257375
-- platform: linux-64
+- kind: conda
   name: pytz
-  version: 2023.3.post1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+  version: '2024.1'
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 187454
-  timestamp: 1693930444432
-- platform: linux-64
+  size: 188538
+  timestamp: 1706886944988
+- kind: conda
   name: pyyaml
   version: 6.0.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py310h2372a71_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+  sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
+  md5: bb010e368de4940771368bc3dc4c63e7
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
-  hash:
-    md5: bb010e368de4940771368bc3dc4c63e7
-    sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: MIT
   license_family: MIT
   size: 170627
   timestamp: 1695373587159
-- platform: linux-64
+- kind: conda
   name: pyzmq
-  version: 25.1.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 25.1.2
+  build: py310h795f18f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py310h795f18f_0.conda
+  sha256: 6ce93fd1e847ce02c2bbfa6022b639b21d4229d61b21ce0ecacb22c380e5680e
+  md5: fa09f98f3acfd3f5de30bd2d27d5cb7f
+  depends:
   - libgcc-ng >=12
   - libsodium >=1.0.18,<1.0.19.0a0
   - libstdcxx-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - zeromq >=4.3.5,<4.4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
-  hash:
-    md5: 6391ac95effeebc612023b9507b558b3
-    sha256: 68fa979d6e92ddef0a93d22a4e902383b89db7ca77aab0682272bdeb4b14881a
-  build: py310h795f18f_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 456635
-  timestamp: 1698062566269
-- platform: linux-64
+  size: 456994
+  timestamp: 1701783375385
+- kind: conda
   name: qhull
   version: '2020.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h4bd325d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h4bd325d_2.tar.bz2
+  sha256: e1d6e4e74486ce4844c4bbdc7198bb4d8191b70881f6415d1f4b5fd8d98f18d7
+  md5: 5acb8407fefa1c1929c11c167237e776
+  depends:
   - libgcc-ng >=9.4.0
   - libstdcxx-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h4bd325d_2.tar.bz2
-  hash:
-    md5: 5acb8407fefa1c1929c11c167237e776
-    sha256: e1d6e4e74486ce4844c4bbdc7198bb4d8191b70881f6415d1f4b5fd8d98f18d7
-  build: h4bd325d_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: Qhull
   size: 1971736
   timestamp: 1631546549823
-- platform: linux-64
+- kind: conda
   name: rav1e
   version: 0.6.6
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
-  hash:
-    md5: 77d9955b4abddb811cb8ab1aa7d743e4
-    sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
   build: he8a937b_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+  sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  md5: 77d9955b4abddb811cb8ab1aa7d743e4
+  depends:
+  - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
   size: 15423721
   timestamp: 1694329261357
-- platform: linux-64
+- kind: conda
   name: re2
-  version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h7a70373_0
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
-  hash:
-    md5: bb2d5e593ef13fe4aff0bc9440f945ae
-    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
-  build: h2873b5e_0
-  arch: x86_64
+  version: 2023.09.01
+  build: h7f4b329_2
+  build_number: 2
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+  sha256: f0f520f57e6b58313e8c41abc7dfa48742a05f1681f05654558127b667c769a8
+  md5: 8f70e36268dea8eb666ef14c29bd3cda
+  depends:
+  - libre2-11 2023.09.01 h5a48ba9_2
   license: BSD-3-Clause
   license_family: BSD
-  size: 26953
-  timestamp: 1697065840782
-- platform: linux-64
+  size: 26617
+  timestamp: 1708946796423
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  build: h8228510_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: GPL-3.0-only
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- platform: linux-64
+- kind: conda
   name: referencing
-  version: 0.30.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.33.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
+  sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
+  md5: bc415a1c6cf049166215d6b596e0fcbe
+  depends:
   - attrs >=22.2.0
   - python >=3.8
   - rpds-py >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: a33161b983172ba6ef69d5fc850650cd
-    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 38061
-  timestamp: 1691337409918
-- platform: linux-64
+  size: 39055
+  timestamp: 1706711589688
+- kind: conda
   name: requests
   version: 2.31.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
   - certifi >=2017.4.17
   - charset-normalizer >=2,<4
   - idna >=2.5,<4
   - python >=3.7
   - urllib3 >=1.21.1,<3
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - chardet >=3.0.2,<6
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 56690
   timestamp: 1684774408600
-- platform: linux-64
+- kind: conda
   name: rfc3339-validator
   version: 0.1.4
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
   - python >=3.5
   - six
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 8064
   timestamp: 1638811838081
-- platform: linux-64
+- kind: conda
   name: rfc3986-validator
   version: 0.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 912a71cc01012ee38e6b90ddd561e36f
-    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
   build: pyh9f0ad1d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
   license: MIT
   license_family: MIT
-  noarch: python
   size: 7818
   timestamp: 1598024297745
-- platform: linux-64
+- kind: conda
   name: rich
-  version: 13.6.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 13.7.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
+  sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
+  md5: ba445bf767ae6f0d959ff2b40c20912b
+  depends:
   - markdown-it-py >=2.2.0
   - pygments >=2.13.0,<3.0.0
   - python >=3.7.0
   - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ca4829f40710f581ca1d76bc907e99f
-    sha256: a2f8838a75ab8c2c1da0a813c7569d4f6efba0d2b5dc3a7659e2cb6d96bd8e19
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 183200
-  timestamp: 1696096819794
-- platform: linux-64
+  size: 184347
+  timestamp: 1709150578093
+- kind: conda
   name: rpds-py
-  version: 0.12.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.18.0
+  build: py310hcb5633a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.18.0-py310hcb5633a_0.conda
+  sha256: 180f734f14402a3605cc0d0a70dd52539c87ba76337da6eb73ebf603c8405c6b
+  md5: eca3962963d1de0a4d13572ba943b61d
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.12.0-py310hcb5633a_0.conda
-  hash:
-    md5: 559e61c9a0a1b0a905965a60e5243cee
-    sha256: 7364e531276bdcad8e805685684a542f046b5693cf9cd20fa6804b01bda09200
-  build: py310hcb5633a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  size: 986315
-  timestamp: 1699110079552
-- platform: linux-64
+  size: 915667
+  timestamp: 1707922907509
+- kind: conda
   name: scipy
-  version: 1.11.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.12.0
+  build: py310hb13e2d6_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.12.0-py310hb13e2d6_2.conda
+  sha256: 336c5c1b29441b99033375d084ed24a65bea852a02b3c79954134fc5ada8c6c4
+  md5: cd3baec470071490bc5ab05da64c52b5
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
@@ -5424,1230 +4896,851 @@ package:
   - numpy >=1.22.4,<2.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
-  hash:
-    md5: 4260b359d8fbeab4f789a8b0f968079f
-    sha256: bb8cdaf0869979ef58b3c10491f235c0fabf0b091e591361d25a4ffd47d6aded
-  build: py310hb13e2d6_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 14983190
-  timestamp: 1696468679504
-- platform: linux-64
+  size: 16486180
+  timestamp: 1706042692665
+- kind: conda
   name: send2trash
   version: 1.8.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyh41d4057_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+  md5: ada5a17adcd10be4fc7e37e4166ba0e2
+  depends:
   - __linux
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
-  hash:
-    md5: ada5a17adcd10be4fc7e37e4166ba0e2
-    sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
-  build: pyh41d4057_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 22821
   timestamp: 1682601391911
-- platform: linux-64
+- kind: conda
   name: setuptools
-  version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  version: 69.2.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+  sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
+  md5: da214ecd521a720a9d521c68047682dc
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 464399
-  timestamp: 1694548452441
-- platform: linux-64
+  size: 471183
+  timestamp: 1710344615844
+- kind: conda
   name: six
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   build: pyh6c4a22f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
   license: MIT
   license_family: MIT
-  noarch: python
   size: 14259
   timestamp: 1620240338595
-- platform: linux-64
+- kind: conda
   name: snappy
   version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
+  build: h9fff704_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  hash:
-    md5: e6d228cd0bb74a51dd18f5bfce0b4115
-    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  build: h9fff704_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   size: 38865
   timestamp: 1678534590321
-- platform: linux-64
+- kind: conda
   name: sniffio
-  version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd6cbc539e74cb1f430efbd4575b9303
-    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  version: 1.3.1
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  md5: 490730480d76cf9c8f8f2849719c6e2b
+  depends:
+  - python >=3.7
   license: Apache-2.0
   license_family: Apache
-  noarch: python
-  size: 14358
-  timestamp: 1662051357638
-- platform: linux-64
+  size: 15064
+  timestamp: 1708953086199
+- kind: conda
   name: soupsieve
   version: '2.5'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
-    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
   size: 36754
   timestamp: 1693929424267
-- platform: linux-64
+- kind: conda
   name: stack_data
   version: 0.6.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
   - asttokens
   - executing
   - pure_eval
   - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 26205
   timestamp: 1669632203115
-- platform: linux-64
+- kind: conda
   name: svt-av1
-  version: 1.7.0
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.0.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.0.0-h59595ed_0.conda
+  sha256: eee484177184c7876d258917ab3f209396e6fc59e9bf3603a3ebf1ce8b39df80
+  md5: 207e01ffa0eb2d2efb83fb6f46365a21
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.7.0-h59595ed_0.conda
-  hash:
-    md5: b6e0b4f1edc2740d1cf87669195c39d4
-    sha256: e79878bba3b013db1b59766895a182dd12d2e1a45e24c01b61b4e922ed8500b6
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-2-Clause
   license_family: BSD
-  size: 2641420
-  timestamp: 1692966629866
-- platform: linux-64
+  size: 2633794
+  timestamp: 1710374004661
+- kind: conda
+  name: sysroot_linux-64
+  version: '2.28'
+  build: he073ed8_1
+  build_number: 1
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-he073ed8_1.conda
+  sha256: ffa6c4b7d33eb6c5058948f42ed3e0b928c16ae8fec2c5c2916ecdec194f779e
+  md5: 108c483995978cb8040354cd5c499eeb
+  depends:
+  - _sysroot_linux-64_curr_repodata_hack 3.*
+  - kernel-headers_linux-64 4.18.0 he073ed8_1
+  track_features:
+  - sysroot_linux-64_2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 25962356
+  timestamp: 1708000865356
+- kind: conda
   name: tensorboardx
   version: 2.6.2.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tensorboardx-2.6.2.2-pyhd8ed1ab_0.conda
+  sha256: a4bfd5a49fa3b5972c999345a1929079573fe9da5f9c12986eb83ee316f4d829
+  md5: eddae4814ac4040d88009779fc1e2d9e
+  depends:
   - numpy
   - packaging
   - protobuf >=3.20
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/tensorboardx-2.6.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: eddae4814ac4040d88009779fc1e2d9e
-    sha256: a4bfd5a49fa3b5972c999345a1929079573fe9da5f9c12986eb83ee316f4d829
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
   size: 76311
   timestamp: 1692548918503
-- platform: linux-64
+- kind: conda
   name: tensorstore
-  version: 0.1.44
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.1.56
+  build: py310h3c30d94_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tensorstore-0.1.56-py310h3c30d94_0.conda
+  sha256: f6d1bf8f3afa46915f8b521b7828dc0adfa5134f8a0f04389199751b1c1b3f3f
+  md5: 39413a7f74444419b415f801ef7f1a86
+  depends:
   - blosc >=1.21.5,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - libavif16 >=1.0.1,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
+  - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
+  - ml_dtypes
   - numpy >=1.22.4,<2.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - pybind11-abi 4
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tensorstore-0.1.44-py310h8ba0d1c_3.conda
-  hash:
-    md5: d973a0bc81bfb714f60d41fa86269d90
-    sha256: 09f425653f50240d015df5005745a2aaec355ae896c153831892dc13933d761b
-  build: py310h8ba0d1c_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: Apache-2.0 AND MIT AND BSD-3-Clause AND BSD-2-Clause
-  size: 7648891
-  timestamp: 1698737414075
-- platform: linux-64
+  size: 8309884
+  timestamp: 1710583374829
+- kind: conda
   name: terminado
-  version: 0.17.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 0.18.1
+  build: pyh0d859eb_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
   - __linux
   - ptyprocess
-  - python >=3.7
+  - python >=3.8
   - tornado >=6.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
-  hash:
-    md5: 3788984d535770cad699efaeb6cb3037
-    sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
-  build: pyh41d4057_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
-  size: 20787
-  timestamp: 1670253786972
-- platform: linux-64
+  size: 22452
+  timestamp: 1710262728753
+- kind: conda
   name: tinycss2
   version: 1.2.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  depends:
   - python >=3.5
   - webencodings >=0.4
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 23235
   timestamp: 1666100385187
-- platform: linux-64
+- kind: conda
   name: tinyxml2
-  version: 9.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-9.0.0-h9c3ff4c_2.tar.bz2
-  hash:
-    md5: 665e72841695a5da54c285d4fbe11a59
-    sha256: 87732397a511fb6ccc6709bedb64ddb8921c50a2eb4a78ffb0405dd506bfbe8f
-  build: h9c3ff4c_2
-  arch: x86_64
+  version: 10.0.0
+  build: h59595ed_0
   subdir: linux-64
-  build_number: 2
+  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
+  sha256: e89306d01999f629a329ddb2e2ca9b8fbfe7c483d13f9805f0c6891a24a6e9c8
+  md5: 5e27e4a780264caed4be372ded70a9e9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: Zlib
-  size: 121628
-  timestamp: 1639147682702
-- platform: linux-64
+  size: 120640
+  timestamp: 1704495493222
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
+  build: noxft_h4845f30_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  hash:
-    md5: d453b98d9c83e71da0741bb0ff4d76bc
-    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  build: noxft_h4845f30_101
-  arch: x86_64
-  subdir: linux-64
-  build_number: 101
   license: TCL
   license_family: BSD
   size: 3318875
   timestamp: 1699202167581
-- platform: linux-64
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: linux-64
+- kind: conda
   name: toolz
-  version: 0.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 92facfec94bc02d6ccf42e7173831a36
-    sha256: 90229da7665175b0185183ab7b53f50af487c7f9b0f47cf09c184cbc139fd24b
+  version: 0.12.1
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+  sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
+  md5: 2fcb582444635e2c402e8569bb94e039
+  depends:
+  - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 49136
-  timestamp: 1657485654230
-- platform: linux-64
+  size: 52358
+  timestamp: 1706112720607
+- kind: conda
   name: tornado
-  version: 6.3.3
-  category: main
-  manager: conda
-  dependencies:
+  version: '6.4'
+  build: py310h2372a71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4-py310h2372a71_0.conda
+  sha256: bf3f211554444e03ed4663c0704fada38e0440fa723f1e32e12243ab026e3817
+  md5: 48f39c24349d9ae5c8e8873c42fb6170
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
-  hash:
-    md5: b23e0147fa5f7a9380e06334c7266ad5
-    sha256: 209b6788b81739d3cdc2f04ad3f6f323efd85b1a30f2edce98ab76d98079fac8
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 641597
-  timestamp: 1695373710038
-- platform: linux-64
+  size: 650910
+  timestamp: 1708363310348
+- kind: conda
   name: traitlets
-  version: 5.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8a9953c15e1e5a7c1baddbbf4511a567
-    sha256: 7ac67960ba2e8c16818043cc65ac6190fa4fd95f5b24357df58e4f73d5e60a10
+  version: 5.14.2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
+  sha256: 9ea6073091c130470a51b51703c8d2d959434992e29c4aa4abeba07cd56533a3
+  md5: af5fa2d2186003472e766a23c46cae04
+  depends:
+  - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
-  size: 109701
-  timestamp: 1698671281969
-- platform: linux-64
+  size: 110288
+  timestamp: 1710254564088
+- kind: conda
   name: trimesh
-  version: 4.0.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.2.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 4f75f9b470755e6d549b19cedd6a59513f31456a1290ccc360c95d521cae1fec
+  md5: 6dde89be664d3b2c2472fc10e26e4fec
+  depends:
   - numpy
   - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 09fa6ac1ba8d34503309a46be72cbf8d
-    sha256: f5ddc407936beef8a684ba9a713eda82fccf54076524aaa06db1d2425e6ab063
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - pillow
+  - networkx
+  - xxhash
+  - scikit-image
+  - sympy
+  - psutil
+  - lxml
+  - chardet
+  - colorlog
+  - meshio
   - requests
+  - svg.path
+  - jsonschema
+  - pillow
+  - mapbox_earcut
+  - pycollada
+  - setuptools
+  - shapely
+  - rtree
   - msgpack-python
   - scipy
-  - meshio
-  - pycollada
-  - psutil
-  - networkx
-  - svg.path
-  - scikit-image
-  - chardet
-  - rtree
-  - sympy
-  - shapely
-  - xxhash
-  - mapbox_earcut
-  - lxml
-  - setuptools
   - pyglet
-  - colorlog
-  - jsonschema
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 558629
-  timestamp: 1699420584381
-- platform: linux-64
+  size: 558165
+  timestamp: 1710196615199
+- kind: conda
   name: types-python-dateutil
-  version: 2.8.19.14
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4df15c51a543e806d439490b862be1c6
-    sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  version: 2.9.0.20240316
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+  md5: 7831efa91d57475373ee52fb92e8d137
+  depends:
+  - python >=3.6
   license: Apache-2.0 AND MIT
-  noarch: python
-  size: 21474
-  timestamp: 1689883066161
-- platform: linux-64
+  size: 21769
+  timestamp: 1710590028155
+- kind: conda
   name: typing-extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions 4.8.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  version: 4.10.0
   build: hd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
+  sha256: 0698fe2c4e555fb44c27c60f7a21fa0eea7f5bf8186ad109543c5b056e27f96a
+  md5: 091683b9150d2ebaa62fd7e2c86433da
+  depends:
+  - typing_extensions 4.10.0 pyha770c72_0
   license: PSF-2.0
   license_family: PSF
-  noarch: python
-  size: 10104
-  timestamp: 1695040958008
-- platform: linux-64
+  size: 10181
+  timestamp: 1708904805365
+- kind: conda
   name: typing_extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  version: 4.10.0
   build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
+  sha256: 4be24d557897b2f6609f5d5f7c437833c62f4d4a96581e39530067e96a2d0451
+  md5: 16ae769069b380646c47142d719ef466
+  depends:
+  - python >=3.8
   license: PSF-2.0
   license_family: PSF
-  noarch: python
-  size: 35108
-  timestamp: 1695040948828
-- platform: linux-64
+  size: 37018
+  timestamp: 1708904796013
+- kind: conda
   name: typing_utils
   version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 13829
   timestamp: 1622899345711
-- platform: linux-64
+- kind: conda
   name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
+  version: 2024a
+  build: h0c530f3_0
+  subdir: noarch
   noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  md5: 161081fc7cec0bfda0d86d7cb595f8d8
+  license: LicenseRef-Public-Domain
+  size: 119815
+  timestamp: 1706886945727
+- kind: conda
   name: unicodedata2
   version: 15.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py310h2372a71_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+  sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
+  md5: 72637c58d36d9475fda24700c9796f19
+  depends:
   - libgcc-ng >=12
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
-  hash:
-    md5: 72637c58d36d9475fda24700c9796f19
-    sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: Apache-2.0
   license_family: Apache
   size: 374055
   timestamp: 1695848183607
-- platform: linux-64
+- kind: conda
   name: uri-template
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
   license: MIT
   license_family: MIT
-  noarch: python
   size: 23999
   timestamp: 1688655976471
-- platform: linux-64
+- kind: conda
   name: urllib3
-  version: 2.0.7
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.2.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
+  sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
+  md5: 08807a87fa7af10754d46f63b368e016
+  depends:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 98507
-  timestamp: 1697720586316
-- platform: linux-64
+  size: 94669
+  timestamp: 1708239595549
+- kind: conda
+  name: wayland
+  version: 1.22.0
+  build: h8c25dac_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.22.0-h8c25dac_1.conda
+  sha256: 9bf43998c0a4c7bff53849c8ef7638415020f9033f397a63537dfca1bf66e26a
+  md5: bfe70f700e76c87e0074c3e308513e79
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 306491
+  timestamp: 1684198293803
+- kind: conda
   name: wcwidth
-  version: 0.2.9
-  category: main
-  manager: conda
-  dependencies:
-  - backports.functools_lru_cache
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8e8280dec091763dfdc29e066de52270
-    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+  version: 0.2.13
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  md5: 68f0738df502a14213624b288c60c9ad
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 30316
-  timestamp: 1698744892384
-- platform: linux-64
+  size: 32709
+  timestamp: 1704731373922
+- kind: conda
   name: webcolors
   version: '1.13'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  md5: 166212fe82dad8735550030488a01d03
+  depends:
+  - python >=3.5
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 18186
   timestamp: 1679900907305
-- platform: linux-64
+- kind: conda
   name: webencodings
   version: 0.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.6
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
   build: pyhd8ed1ab_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 15600
   timestamp: 1694681458271
-- platform: linux-64
+- kind: conda
   name: websocket-client
-  version: 1.6.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: bdb77b28cf16deac0eef431a068320e8
-    sha256: df45b89862edcd7cd5180ec7b8c0c0ca9fb4d3f7d49ddafccdc76afcf50d8da6
+  version: 1.7.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+  sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
+  md5: 50ad31e07d706aae88b14a4ac9c73f23
+  depends:
+  - python >=3.8
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
-  size: 45866
-  timestamp: 1696770282111
-- platform: linux-64
+  size: 46626
+  timestamp: 1701630814576
+- kind: conda
   name: werkzeug
   version: 3.0.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
+  md5: af8d825d93dbe6331ee6d61c69869ca0
+  depends:
   - markupsafe >=2.1.1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: af8d825d93dbe6331ee6d61c69869ca0
-    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 241704
   timestamp: 1698235401441
-- platform: linux-64
+- kind: conda
   name: wheel
-  version: 0.41.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3fc026b9c87d091c4b34a6c997324ae8
-    sha256: 84c3b57fba778add2bd47b7cc70e86f746d2c55549ffd2ccb6f3d6bf7c94d21d
+  version: 0.42.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+  sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+  md5: 1cdea58981c5cbc17b51973bcaddcea7
+  depends:
+  - python >=3.7
   license: MIT
   license_family: MIT
-  noarch: python
-  size: 57901
-  timestamp: 1698670970223
-- platform: linux-64
+  size: 57553
+  timestamp: 1701013309664
+- kind: conda
   name: x264
-  version: 1!164.3095
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-  hash:
-    md5: 6c99772d483f566d59e25037fea2c4b1
-    sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
-  build: h166bdaf_2
-  arch: x86_64
+  version: 1!161.3030
+  build: h7f98852_1
+  build_number: 1
   subdir: linux-64
-  build_number: 2
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 897548
-  timestamp: 1660323080555
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!161.3030-h7f98852_1.tar.bz2
+  sha256: d8b0b52d1239536889b410d2eef380e9812f5ccc5e28dcc2675abb092f1b1155
+  md5: 4c9106542ee02c991b64b575ca4ea029
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-2.0
+  size: 2576600
+  timestamp: 1623827531989
+- kind: conda
   name: x265
   version: '3.5'
-  category: main
-  manager: conda
-  dependencies:
+  build: h924138e_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
   - libgcc-ng >=10.3.0
   - libstdcxx-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-  hash:
-    md5: e7f6ed84d4623d52ee581325c1587a6b
-    sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
-  build: h924138e_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   license: GPL-2.0-or-later
   license_family: GPL
   size: 3357188
   timestamp: 1646609687141
-- platform: linux-64
-  name: xorg-fixesproto
-  version: '5.0'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  - xorg-xextproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
-  hash:
-    md5: 65ad6e1eb4aed2b0611855aff05e04f6
-    sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
-  build: h7f98852_1002
-  arch: x86_64
+- kind: conda
+  name: xkeyboard-config
+  version: '2.41'
+  build: hd590300_0
   subdir: linux-64
-  build_number: 1002
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+  sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
+  md5: 81f740407b45e3f9047b3174fa94eb9e
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
   license: MIT
   license_family: MIT
-  size: 9122
-  timestamp: 1617479697350
-- platform: linux-64
+  size: 898045
+  timestamp: 1707104384997
+- kind: conda
   name: xorg-kbproto
   version: 1.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
   build: h7f98852_1002
-  arch: x86_64
-  subdir: linux-64
   build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
   size: 27338
   timestamp: 1610027759842
-- platform: linux-64
-  name: xorg-libice
-  version: 1.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
-  hash:
-    md5: b462a33c0be1421532f28bfe8f4a7514
-    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 58469
-  timestamp: 1685307573114
-- platform: linux-64
-  name: xorg-libsm
-  version: 1.2.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-  hash:
-    md5: 93ee23f12bc2e684548181256edd2cf6
-    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  build: h7391055_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 27433
-  timestamp: 1685453649160
-- platform: linux-64
+- kind: conda
   name: xorg-libx11
   version: 1.8.7
-  category: main
-  manager: conda
-  dependencies:
+  build: h8ee46fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+  sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
+  md5: 49e482d882669206653b095f5206c05b
+  depends:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
   - xorg-kbproto
   - xorg-xextproto >=7.3.0,<8.0a0
   - xorg-xproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
-  hash:
-    md5: 49e482d882669206653b095f5206c05b
-    sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
-  build: h8ee46fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 828692
   timestamp: 1697056910935
-- platform: linux-64
+- kind: conda
   name: xorg-libxau
   version: 1.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-  hash:
-    md5: 2c80dc38fface310c9bd81b17037fee5
-    sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
   size: 14468
   timestamp: 1684637984591
-- platform: linux-64
-  name: xorg-libxcursor
-  version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-libxfixes 5.0.*
-  - xorg-libxrender 0.9.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.0-h0b41bf4_1.conda
-  hash:
-    md5: b58859de3b5972860c36f638c8c0ebb6
-    sha256: 109cffb4c07cec101fad55b3f8f8d1e83bb7acef00798a7d2fd6992f14218189
-  build: h0b41bf4_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 31383
-  timestamp: 1677037230603
-- platform: linux-64
+- kind: conda
   name: xorg-libxdmcp
   version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
-  hash:
-    md5: be93aabceefa2fac576e971aef407908
-    sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
   build: h7f98852_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
   size: 19126
   timestamp: 1610071769228
-- platform: linux-64
+- kind: conda
   name: xorg-libxext
   version: 1.3.4
-  category: main
-  manager: conda
-  dependencies:
+  build: h0b41bf4_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
   - libgcc-ng >=12
   - xorg-libx11 >=1.7.2,<2.0a0
   - xorg-xextproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
-  hash:
-    md5: 82b6df12252e6f32402b96dacc656fec
-    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  build: h0b41bf4_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
   license: MIT
   license_family: MIT
   size: 50143
   timestamp: 1677036907815
-- platform: linux-64
-  name: xorg-libxfixes
-  version: 5.0.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  - xorg-fixesproto
-  - xorg-libx11 >=1.7.0,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
-  hash:
-    md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
-    sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
-  build: h7f98852_1004
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1004
-  license: MIT
-  license_family: MIT
-  size: 18145
-  timestamp: 1617717802636
-- platform: linux-64
+- kind: conda
   name: xorg-libxinerama
   version: 1.1.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
+  sha256: 0dc50f019ab9871bd9a8be0b00a1e0fa98172ef9c775a13e2dac2924844bb75e
+  md5: 2e1c65825c586444df23784f68bef90e
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - xorg-libxext
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
-  hash:
-    md5: 2e1c65825c586444df23784f68bef90e
-    sha256: 0dc50f019ab9871bd9a8be0b00a1e0fa98172ef9c775a13e2dac2924844bb75e
-  build: h27087fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT
   license_family: MIT
   size: 13350
   timestamp: 1667399989190
-- platform: linux-64
-  name: xorg-libxrandr
-  version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  - xorg-libx11 >=1.7.1,<2.0a0
-  - xorg-libxext
-  - xorg-libxrender
-  - xorg-randrproto
-  - xorg-renderproto
-  - xorg-xextproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.2-h7f98852_1.tar.bz2
-  hash:
-    md5: 5b0f7da25a4556c9619c3e4b4a98ab07
-    sha256: ffd075a463896ed86d9519e26dc36f754b695b9c1e1b6115d34fe138b36d8200
-  build: h7f98852_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 29688
-  timestamp: 1621515728586
-- platform: linux-64
-  name: xorg-libxrender
-  version: 0.9.11
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-renderproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
-  hash:
-    md5: ed67c36f215b310412b2af935bf3e530
-    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 37770
-  timestamp: 1688300707994
-- platform: linux-64
-  name: xorg-randrproto
-  version: 1.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-randrproto-1.5.0-h7f98852_1001.tar.bz2
-  hash:
-    md5: 68cce654461713977dac6f9ac1bce89a
-    sha256: f5c7c2de3655a95153e900118959df6a50b6c104a3d7afaee3eadbf86b85fa2e
-  build: h7f98852_1001
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1001
-  license: MIT
-  license_family: MIT
-  size: 32984
-  timestamp: 1621340029170
-- platform: linux-64
-  name: xorg-renderproto
-  version: 0.11.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-  hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  build: h7f98852_1002
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1002
-  license: MIT
-  license_family: MIT
-  size: 9621
-  timestamp: 1614866326326
-- platform: linux-64
+- kind: conda
   name: xorg-xextproto
   version: 7.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-  hash:
-    md5: bce9f945da8ad2ae9b1d7165a64d0f87
-    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
   build: h0b41bf4_1003
-  arch: x86_64
-  subdir: linux-64
   build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
   size: 30270
   timestamp: 1677036833037
-- platform: linux-64
+- kind: conda
   name: xorg-xproto
   version: 7.0.31
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-  hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
   build: h7f98852_1007
-  arch: x86_64
-  subdir: linux-64
   build_number: 1007
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
   size: 74922
   timestamp: 1607291557628
-- platform: linux-64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- platform: linux-64
+- kind: conda
   name: yaml
   version: 0.2.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-  hash:
-    md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
-    sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
   build: h7f98852_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
   size: 89141
   timestamp: 1641346969816
-- platform: linux-64
+- kind: conda
   name: zeromq
   version: 4.3.5
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
+  sha256: 3bec658f5c23abf5e200d98418add7a20ff7b45c928ad4560525bef899496256
+  md5: 7fc9d3288d2420bb3637647621018000
+  depends:
   - libgcc-ng >=12
   - libsodium >=1.0.18,<1.0.19.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
-  hash:
-    md5: 8851084c192dbc56215ac4e3c9aa30fa
-    sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 343455
-  timestamp: 1697056638125
-- platform: linux-64
+  size: 343438
+  timestamp: 1709135220800
+- kind: conda
   name: zipp
   version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
   license: MIT
   license_family: MIT
-  noarch: python
   size: 18954
   timestamp: 1695255262261
-- platform: linux-64
+- kind: conda
   name: zlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
   - libgcc-ng >=12
   - libzlib 1.2.13 hd590300_5
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: 68c34ec6149623be41a1933ab996a209
-    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
   license: Zlib
   license_family: Other
   size: 92825
   timestamp: 1686575231103
-- platform: linux-64
+- kind: conda
   name: zstd
   version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  build: hfc55251_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   size: 545199
   timestamp: 1693151163452
-version: 1

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,23 +1,24 @@
 [project]
 name = "mujoco-mjx-pixi-example"
-version = "0.1.0"
+version = "0.2.0"
 description = "Example of using MuJoCo MJX with CUDA acceleration and pixi"
 authors = ["Silvio Traversaro <silvio.traversaro@iit.it>"]
-channels = ["conda-forge", "nvidia"]
+channels = ["conda-forge"]
 platforms = ["linux-64"]
 
 [system-requirements]
-unix = true
-cuda = "11.8"
+cuda = "12"
 
 [tasks]
 notebook_tutorial = "jupyter notebook tutorial.ipynb"
 
 [dependencies]
-brax       = "0.9.3.*"
-mujoco     = "3.0.0.*"
-mujoco-mjx = "3.0.0.*"
+brax       = "*"
+mujoco     = "3.1.3"
+mujoco-mjx = "*"
 notebook   = "*"
 mediapy    = "*"
-cuda-nvcc  = "11.8.*"
+cuda-version = "12.*"
+cuda-nvcc  = "*"
+cuda-cupti = "*"
 pip        = "*"

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -1,1404 +1,1465 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MpkYHwCqk7W-"
-      },
-      "source": [
-        "![MuJoCo banner](https://raw.githubusercontent.com/google-deepmind/mujoco/main/banner.png)\n",
-        "\n",
-        "# <h1><center>Tutorial  <a href=\"https://colab.research.google.com/github/google-deepmind/mujoco/blob/main/mjx/tutorial.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" width=\"140\" align=\"center\"/></a></center></h1>\n",
-        "\n",
-        "This notebook provides an introductory tutorial for [**MuJoCo XLA (MJX)**](https://github.com/google-deepmind/mujoco/blob/main/mjx), a JAX-based implementation of MuJoCo useful for RL training workloads.\n",
-        "\n",
-        "**A Colab runtime with GPU acceleration is required.** If you're using a CPU-only runtime, you can switch using the menu \"Runtime > Change runtime type\".\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xBSdkbmGN2K-"
-      },
-      "source": [
-        "### Copyright notice"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_UbO9uhtBSX5"
-      },
-      "source": [
-        "> <p><small><small>Copyright 2023 DeepMind Technologies Limited.</small></p>\n",
-        "> <p><small><small>Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <a href=\"http://www.apache.org/licenses/LICENSE-2.0\">http://www.apache.org/licenses/LICENSE-2.0</a>.</small></small></p>\n",
-        "> <p><small><small>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</small></small></p>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YvyGCsgSCxHQ"
-      },
-      "source": [
-        "# Install MuJoCo, MJX, and Brax"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Xqo7pyX-n72M"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install mujoco\n",
-        "!pip install mujoco_mjx\n",
-        "!pip install brax"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "IbZxYDxzoz5R"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Check if MuJoCo installation was successful\n",
-        "\n",
-        "import distutils.util\n",
-        "import os\n",
-        "import subprocess\n",
-        "if subprocess.run('nvidia-smi').returncode:\n",
-        "  raise RuntimeError(\n",
-        "      'Cannot communicate with GPU. '\n",
-        "      'Make sure you are using a GPU Colab runtime. '\n",
-        "      'Go to the Runtime menu and select Choose runtime type.')\n",
-        "\n",
-        "# Configure MuJoCo to use the EGL rendering backend (requires GPU)\n",
-        "print('Setting environment variable to use GPU rendering:')\n",
-        "%env MUJOCO_GL=egl\n",
-        "\n",
-        "try:\n",
-        "  print('Checking that the installation succeeded:')\n",
-        "  import mujoco\n",
-        "  mujoco.MjModel.from_xml_string('<mujoco/>')\n",
-        "except Exception as e:\n",
-        "  raise e from RuntimeError(\n",
-        "      'Something went wrong during installation. Check the shell output above '\n",
-        "      'for more information.\\n'\n",
-        "      'If using a hosted Colab runtime, make sure you enable GPU acceleration '\n",
-        "      'by going to the Runtime menu and selecting \"Choose runtime type\".')\n",
-        "\n",
-        "print('Installation successful.')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "T5f4w3Kq2X14"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Import packages for plotting and creating graphics\n",
-        "import time\n",
-        "import itertools\n",
-        "import numpy as np\n",
-        "from typing import Callable, NamedTuple, Optional, Union, List\n",
-        "\n",
-        "# Graphics and plotting.\n",
-        "print('Installing mediapy:')\n",
-        "!command -v ffmpeg >/dev/null || (apt update && apt install -y ffmpeg)\n",
-        "!pip install -q mediapy\n",
-        "import mediapy as media\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "# More legible printing from numpy.\n",
-        "np.set_printoptions(precision=3, suppress=True, linewidth=100)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "ObF1UXrkb0Nd"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Import MuJoCo, MJX, and Brax\n",
-        "\n",
-        "from datetime import datetime\n",
-        "import functools\n",
-        "import jax\n",
-        "from jax import numpy as jp\n",
-        "import numpy as np\n",
-        "from typing import Any, Dict, Tuple, Union\n",
-        "\n",
-        "from brax import envs\n",
-        "from brax import math\n",
-        "from brax.base import Base, Motion, Transform\n",
-        "from brax.envs.base import Env, State\n",
-        "from brax.training.agents.ppo import train as ppo\n",
-        "from brax.training.agents.ppo import networks as ppo_networks\n",
-        "from brax.io import model\n",
-        "from etils import epath\n",
-        "from flax import struct\n",
-        "from matplotlib import pyplot as plt\n",
-        "import mediapy as media\n",
-        "from ml_collections import config_dict\n",
-        "import mujoco\n",
-        "from mujoco import mjx\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RAv6WUVUm78k"
-      },
-      "source": [
-        "# Training a Policy with MJX\n",
-        "MJX is an implementation of MuJoCo written in [JAX](https://jax.readthedocs.io/en/latest/index.html), enabling large batch training on GPU/TPU. In this notebook, we demonstrate how to train RL policies with MJX.\n",
-        "\n",
-        "First, we implement an environment `State` so that we can plug into the [Brax](https://github.com/google/brax) environment API. `State` holds the observation, reward, metrics, and environment info. Notably `State.pipeline_state` holds a `mjx.Data` object, which is analogous to `mjData` in MuJoCo.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7DQ_rW4CkIB_"
-      },
-      "outputs": [],
-      "source": [
-        "#@title State\n",
-        "\n",
-        "@struct.dataclass\n",
-        "class State(Base):\n",
-        "  \"\"\"Environment state for training and inference with brax.\n",
-        "\n",
-        "  Args:\n",
-        "    pipeline_state: the physics state, mjx.Data\n",
-        "    obs: environment observations\n",
-        "    reward: environment reward\n",
-        "    done: boolean, True if the current episode has terminated\n",
-        "    metrics: metrics that get tracked per environment step\n",
-        "    info: environment variables defined and updated by the environment reset\n",
-        "      and step functions\n",
-        "  \"\"\"\n",
-        "\n",
-        "  pipeline_state: mjx.Data\n",
-        "  obs: jax.Array\n",
-        "  reward: jax.Array\n",
-        "  done: jax.Array\n",
-        "  metrics: Dict[str, jax.Array] = struct.field(default_factory=dict)\n",
-        "  info: Dict[str, Any] = struct.field(default_factory=dict)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "acpXtDLNXLV9"
-      },
-      "source": [
-        "\n",
-        "Next, we implement `MjxEnv`, an environment class we'll use through the notebook. `MjxEnv` initializes a `mjx.Model` and `mjx.Data` object. Notice that `MjxEnv` calls `mjx.step` for every `pipeline_step`, which is analgous to `mujoco.mj_step`.\n",
-        "\n",
-        "`MjxEnv` also inherits from `brax.envs.base.Env` which allows us to use the training agents implemented in brax."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ccujYeJ5XOhx"
-      },
-      "outputs": [],
-      "source": [
-        "#@title MjxEnv\n",
-        "\n",
-        "class MjxEnv(Env):\n",
-        "  \"\"\"API for driving an MJX system for training and inference in brax.\"\"\"\n",
-        "\n",
-        "  def __init__(\n",
-        "      self,\n",
-        "      mj_model: mujoco.MjModel,\n",
-        "      physics_steps_per_control_step: int = 1,\n",
-        "  ):\n",
-        "    \"\"\"Initializes MjxEnv.\n",
-        "\n",
-        "    Args:\n",
-        "      mj_model: mujoco.MjModel\n",
-        "      physics_steps_per_control_step: the number of times to step the physics\n",
-        "        pipeline for each environment step\n",
-        "    \"\"\"\n",
-        "    self.model = mj_model\n",
-        "    self.data = mujoco.MjData(mj_model)\n",
-        "    self.sys = mjx.device_put(mj_model)\n",
-        "    self._physics_steps_per_control_step = physics_steps_per_control_step\n",
-        "\n",
-        "  def pipeline_init(\n",
-        "      self, qpos: jax.Array, qvel: jax.Array\n",
-        "  ) -> mjx.Data:\n",
-        "    \"\"\"Initializes the physics state.\"\"\"\n",
-        "    data = mjx.device_put(self.data)\n",
-        "    data = data.replace(qpos=qpos, qvel=qvel, ctrl=jp.zeros(self.sys.nu))\n",
-        "    data = mjx.forward(self.sys, data)\n",
-        "    return data\n",
-        "\n",
-        "  def pipeline_step(\n",
-        "      self, data: mjx.Data, ctrl: jax.Array\n",
-        "  ) -> mjx.Data:\n",
-        "    \"\"\"Takes a physics step using the physics pipeline.\"\"\"\n",
-        "    def f(data, _):\n",
-        "      data = data.replace(ctrl=ctrl)\n",
-        "      return (\n",
-        "          mjx.step(self.sys, data),\n",
-        "          None,\n",
-        "      )\n",
-        "    data, _ = jax.lax.scan(f, data, (), self._physics_steps_per_control_step)\n",
-        "    return data\n",
-        "\n",
-        "  @property\n",
-        "  def dt(self) -> jax.Array:\n",
-        "    \"\"\"The timestep used for each env step.\"\"\"\n",
-        "    return self.sys.opt.timestep * self._physics_steps_per_control_step\n",
-        "\n",
-        "  @property\n",
-        "  def observation_size(self) -> int:\n",
-        "    rng = jax.random.PRNGKey(0)\n",
-        "    reset_state = self.unwrapped.reset(rng)\n",
-        "    return reset_state.obs.shape[-1]\n",
-        "\n",
-        "  @property\n",
-        "  def action_size(self) -> int:\n",
-        "    return self.sys.nu\n",
-        "\n",
-        "  @property\n",
-        "  def backend(self) -> str:\n",
-        "    return 'mjx'\n",
-        "\n",
-        "  def _pos_vel(\n",
-        "      self, data: mjx.Data\n",
-        "      ) -> Tuple[Transform, Motion]:\n",
-        "    \"\"\"Returns 6d spatial transform and 6d velocity for all bodies.\"\"\"\n",
-        "    x = Transform(pos=data.xpos[1:, :], rot=data.xquat[1:, :])\n",
-        "    cvel = Motion(vel=data.cvel[1:, 3:], ang=data.cvel[1:, :3])\n",
-        "    offset = data.xpos[1:, :] - data.subtree_com[\n",
-        "        self.model.body_rootid[np.arange(1, self.model.nbody)]]\n",
-        "    xd = Transform.create(pos=offset).vmap().do(cvel)\n",
-        "    return x, xd\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iPlFu4CiIgBN"
-      },
-      "source": [
-        "Finally we can implement a real environment. We choose to first implement the Humanoid environment. Notice that `reset` initializes a `State`, and `step` steps through the physics step and reward logic. The reward and stepping logic train the Humanoid to run forwards."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "mtGMYNLE3QJN"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Humanoid Env\n",
-        "\n",
-        "class Humanoid(MjxEnv):\n",
-        "\n",
-        "  def __init__(\n",
-        "      self,\n",
-        "      forward_reward_weight=1.25,\n",
-        "      ctrl_cost_weight=0.1,\n",
-        "      healthy_reward=5.0,\n",
-        "      terminate_when_unhealthy=True,\n",
-        "      healthy_z_range=(1.0, 2.0),\n",
-        "      reset_noise_scale=1e-2,\n",
-        "      exclude_current_positions_from_observation=True,\n",
-        "      **kwargs,\n",
-        "  ):\n",
-        "    path = epath.Path(epath.resource_path('mujoco')) / (\n",
-        "        'mjx/benchmark/model/humanoid'\n",
-        "    )\n",
-        "    mj_model = mujoco.MjModel.from_xml_path(\n",
-        "        (path / 'humanoid.xml').as_posix())\n",
-        "    mj_model.opt.solver = mujoco.mjtSolver.mjSOL_CG\n",
-        "    mj_model.opt.iterations = 6\n",
-        "    mj_model.opt.ls_iterations = 6\n",
-        "\n",
-        "    physics_steps_per_control_step = 5\n",
-        "    kwargs['physics_steps_per_control_step'] = kwargs.get(\n",
-        "        'physics_steps_per_control_step', physics_steps_per_control_step)\n",
-        "\n",
-        "    super().__init__(mj_model=mj_model, **kwargs)\n",
-        "\n",
-        "    self._forward_reward_weight = forward_reward_weight\n",
-        "    self._ctrl_cost_weight = ctrl_cost_weight\n",
-        "    self._healthy_reward = healthy_reward\n",
-        "    self._terminate_when_unhealthy = terminate_when_unhealthy\n",
-        "    self._healthy_z_range = healthy_z_range\n",
-        "    self._reset_noise_scale = reset_noise_scale\n",
-        "    self._exclude_current_positions_from_observation = (\n",
-        "        exclude_current_positions_from_observation\n",
-        "    )\n",
-        "\n",
-        "  def reset(self, rng: jp.ndarray) -> State:\n",
-        "    \"\"\"Resets the environment to an initial state.\"\"\"\n",
-        "    rng, rng1, rng2 = jax.random.split(rng, 3)\n",
-        "\n",
-        "    low, hi = -self._reset_noise_scale, self._reset_noise_scale\n",
-        "    qpos = self.sys.qpos0 + jax.random.uniform(\n",
-        "        rng1, (self.sys.nq,), minval=low, maxval=hi\n",
-        "    )\n",
-        "    qvel = jax.random.uniform(\n",
-        "        rng2, (self.sys.nv,), minval=low, maxval=hi\n",
-        "    )\n",
-        "\n",
-        "    data = self.pipeline_init(qpos, qvel)\n",
-        "\n",
-        "    obs = self._get_obs(data, jp.zeros(self.sys.nu))\n",
-        "    reward, done, zero = jp.zeros(3)\n",
-        "    metrics = {\n",
-        "        'forward_reward': zero,\n",
-        "        'reward_linvel': zero,\n",
-        "        'reward_quadctrl': zero,\n",
-        "        'reward_alive': zero,\n",
-        "        'x_position': zero,\n",
-        "        'y_position': zero,\n",
-        "        'distance_from_origin': zero,\n",
-        "        'x_velocity': zero,\n",
-        "        'y_velocity': zero,\n",
-        "    }\n",
-        "    return State(data, obs, reward, done, metrics)\n",
-        "\n",
-        "  def step(self, state: State, action: jp.ndarray) -> State:\n",
-        "    \"\"\"Runs one timestep of the environment's dynamics.\"\"\"\n",
-        "    data0 = state.pipeline_state\n",
-        "    data = self.pipeline_step(data0, action)\n",
-        "\n",
-        "    com_before = data0.subtree_com[1]\n",
-        "    com_after = data.subtree_com[1]\n",
-        "    velocity = (com_after - com_before) / self.dt\n",
-        "    forward_reward = self._forward_reward_weight * velocity[0]\n",
-        "\n",
-        "    min_z, max_z = self._healthy_z_range\n",
-        "    is_healthy = jp.where(data.qpos[2] < min_z, x=0.0, y=1.0)\n",
-        "    is_healthy = jp.where(\n",
-        "        data.qpos[2] > max_z, x=0.0, y=is_healthy\n",
-        "    )\n",
-        "    if self._terminate_when_unhealthy:\n",
-        "      healthy_reward = self._healthy_reward\n",
-        "    else:\n",
-        "      healthy_reward = self._healthy_reward * is_healthy\n",
-        "\n",
-        "    ctrl_cost = self._ctrl_cost_weight * jp.sum(jp.square(action))\n",
-        "\n",
-        "    obs = self._get_obs(data, action)\n",
-        "    reward = forward_reward + healthy_reward - ctrl_cost\n",
-        "    done = 1.0 - is_healthy if self._terminate_when_unhealthy else 0.0\n",
-        "    state.metrics.update(\n",
-        "        forward_reward=forward_reward,\n",
-        "        reward_linvel=forward_reward,\n",
-        "        reward_quadctrl=-ctrl_cost,\n",
-        "        reward_alive=healthy_reward,\n",
-        "        x_position=com_after[0],\n",
-        "        y_position=com_after[1],\n",
-        "        distance_from_origin=jp.linalg.norm(com_after),\n",
-        "        x_velocity=velocity[0],\n",
-        "        y_velocity=velocity[1],\n",
-        "    )\n",
-        "\n",
-        "    return state.replace(\n",
-        "        pipeline_state=data, obs=obs, reward=reward, done=done\n",
-        "    )\n",
-        "\n",
-        "  def _get_obs(\n",
-        "      self, data: mjx.Data, action: jp.ndarray\n",
-        "  ) -> jp.ndarray:\n",
-        "    \"\"\"Observes humanoid body position, velocities, and angles.\"\"\"\n",
-        "    position = data.qpos\n",
-        "    if self._exclude_current_positions_from_observation:\n",
-        "      position = position[2:]\n",
-        "\n",
-        "    # external_contact_forces are excluded\n",
-        "    return jp.concatenate([\n",
-        "        position,\n",
-        "        data.qvel,\n",
-        "        data.cinert[1:].ravel(),\n",
-        "        data.cvel[1:].ravel(),\n",
-        "        data.qfrc_actuator,\n",
-        "    ])\n",
-        "\n",
-        "\n",
-        "envs.register_environment('humanoid', Humanoid)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "P1K6IznI2y83"
-      },
-      "source": [
-        "## Visualize a Rollout\n",
-        "\n",
-        "Let's instantiate the environment and visualize a short rollout.\n",
-        "\n",
-        "NOTE: Since episodes terminates early if the torso is below the healthy z-range, the only relevant contacts for this task are between the feet and the plane. We turn off other contacts."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "EhKLFK54C1CH"
-      },
-      "outputs": [],
-      "source": [
-        "# instantiate the environment\n",
-        "env_name = 'humanoid'\n",
-        "env = envs.get_environment(env_name)\n",
-        "\n",
-        "# define the jit reset/step functions\n",
-        "jit_reset = jax.jit(env.reset)\n",
-        "jit_step = jax.jit(env.step)\n",
-        "\n",
-        "# instantiate the renderer\n",
-        "renderer = mujoco.Renderer(env.model)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "9f2ME2WbA5Ip"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Define a render utility function\n",
-        "\n",
-        "def get_image(state: State, camera: str) -> np.ndarray:\n",
-        "  \"\"\"Renders the environment state.\"\"\"\n",
-        "  d = mujoco.MjData(env.model)\n",
-        "  # write the mjx.Data into an mjData object\n",
-        "  mjx.device_get_into(d, state.pipeline_state)\n",
-        "  mujoco.mj_forward(env.model, d)\n",
-        "  # use the mjData object to update the renderer\n",
-        "  renderer.update_scene(d, camera=camera)\n",
-        "  return renderer.render()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Ph8u-v2Q2xLS"
-      },
-      "outputs": [],
-      "source": [
-        "# initialize the state\n",
-        "state = jit_reset(jax.random.PRNGKey(0))\n",
-        "rollout = [state]\n",
-        "images = [get_image(state, camera='side')]\n",
-        "\n",
-        "# grab a trajectory\n",
-        "for i in range(10):\n",
-        "  ctrl = -0.1 * jp.ones(env.sys.nu)\n",
-        "  state = jit_step(state, ctrl)\n",
-        "  rollout.append(state)\n",
-        "  images.append(get_image(state, camera='side'))\n",
-        "\n",
-        "media.show_video(images, fps=1.0 / env.dt)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BQDG6NQ1CbZD"
-      },
-      "source": [
-        "## Train Humanoid Policy\n",
-        "\n",
-        "Let's finally train a policy with PPO to make the Humanoid run forwards. Training takes about 13-14 minutes on a Tesla V100 GPU."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xLiddQYPApBw"
-      },
-      "outputs": [],
-      "source": [
-        "train_fn = functools.partial(\n",
-        "    ppo.train, num_timesteps=30_000_000, num_evals=5, reward_scaling=0.1,\n",
-        "    episode_length=1000, normalize_observations=True, action_repeat=1,\n",
-        "    unroll_length=10, num_minibatches=32, num_updates_per_batch=8,\n",
-        "    discounting=0.97, learning_rate=3e-4, entropy_cost=1e-3, num_envs=2048,\n",
-        "    batch_size=1024, seed=0)\n",
-        "\n",
-        "\n",
-        "x_data = []\n",
-        "y_data = []\n",
-        "ydataerr = []\n",
-        "times = [datetime.now()]\n",
-        "\n",
-        "max_y, min_y = 13000, 0\n",
-        "def progress(num_steps, metrics):\n",
-        "  times.append(datetime.now())\n",
-        "  x_data.append(num_steps)\n",
-        "  y_data.append(metrics['eval/episode_reward'])\n",
-        "  ydataerr.append(metrics['eval/episode_reward_std'])\n",
-        "\n",
-        "  plt.xlim([0, train_fn.keywords['num_timesteps'] * 1.25])\n",
-        "  plt.ylim([min_y, max_y])\n",
-        "\n",
-        "  plt.xlabel('# environment steps')\n",
-        "  plt.ylabel('reward per episode')\n",
-        "  plt.title(f'y={y_data[-1]:.3f}')\n",
-        "\n",
-        "  plt.errorbar(\n",
-        "      x_data, y_data, yerr=ydataerr)\n",
-        "  plt.show()\n",
-        "\n",
-        "make_inference_fn, params, _= train_fn(environment=env, progress_fn=progress)\n",
-        "\n",
-        "print(f'time to jit: {times[1] - times[0]}')\n",
-        "print(f'time to train: {times[-1] - times[1]}')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YYIch0HEApBx"
-      },
-      "source": [
-        "## Save and Load Policy\n",
-        "\n",
-        "We can save and load the policy using the brax model API."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Z8gI6qH6ApBx"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Save Model\n",
-        "model_path = '/tmp/mjx_brax_policy'\n",
-        "model.save_params(model_path, params)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "h4reaWgxApBx"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Load Model and Define Inference Function\n",
-        "params = model.load_params(model_path)\n",
-        "\n",
-        "inference_fn = make_inference_fn(params)\n",
-        "jit_inference_fn = jax.jit(inference_fn)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0G357XIfApBy"
-      },
-      "source": [
-        "## Visualize Policy\n",
-        "\n",
-        "Finally we can visualize the policy."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "osYasMw4ApBy"
-      },
-      "outputs": [],
-      "source": [
-        "eval_env = envs.get_environment(env_name)\n",
-        "\n",
-        "jit_reset = jax.jit(eval_env.reset)\n",
-        "jit_step = jax.jit(eval_env.step)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "d-UhypudApBy"
-      },
-      "outputs": [],
-      "source": [
-        "# initialize the state\n",
-        "rng = jax.random.PRNGKey(0)\n",
-        "state = jit_reset(rng)\n",
-        "rollout = [state]\n",
-        "images = [get_image(state, camera='side')]\n",
-        "\n",
-        "# grab a trajectory\n",
-        "n_steps = 500\n",
-        "render_every = 2\n",
-        "\n",
-        "for i in range(n_steps):\n",
-        "  act_rng, rng = jax.random.split(rng)\n",
-        "  ctrl, _ = jit_inference_fn(state.obs, act_rng)\n",
-        "  state = jit_step(state, ctrl)\n",
-        "  rollout.append(state)\n",
-        "  if i % render_every == 0:\n",
-        "    images.append(get_image(state, camera='side'))\n",
-        "\n",
-        "  if state.done:\n",
-        "    break\n",
-        "\n",
-        "media.show_video(images, fps=1.0 / eval_env.dt / render_every)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zR-heox6LARK"
-      },
-      "source": [
-        "# MJX Policy in MuJoCo\n",
-        "\n",
-        "Note that we can also perform the physics step using the original MuJoCo python bindings to show that the policy trained in MJX works in MuJoCo."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "w6ixFi4dApBy"
-      },
-      "outputs": [],
-      "source": [
-        "mj_model = eval_env.model\n",
-        "mj_data = mujoco.MjData(mj_model)\n",
-        "\n",
-        "renderer = mujoco.Renderer(mj_model)\n",
-        "ctrl = jp.zeros(mj_model.nu)\n",
-        "\n",
-        "images = []\n",
-        "for i in range(n_steps):\n",
-        "  act_rng, rng = jax.random.split(rng)\n",
-        "\n",
-        "  obs = eval_env._get_obs(mjx.device_put(mj_data), ctrl)\n",
-        "  ctrl, _ = jit_inference_fn(obs, act_rng)\n",
-        "\n",
-        "  mj_data.ctrl = ctrl\n",
-        "  for _ in range(eval_env._physics_steps_per_control_step):\n",
-        "    mujoco.mj_step(mj_model, mj_data)  # Physics step using MuJoCo mj_step.\n",
-        "\n",
-        "  if i % render_every == 0:\n",
-        "    renderer.update_scene(mj_data, camera='side')\n",
-        "    images.append(renderer.render())\n",
-        "\n",
-        "media.show_video(images, fps=1.0 / eval_env.dt / render_every)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "65mIPj6DQNNa"
-      },
-      "source": [
-        "# Domain Randomization\n",
-        "\n",
-        "We might also want to include randomization over certain `mjModel` parameters while training a policy. In MJX, we can easily create a batch of environments with randomized values populated in `mjx.Model`. Below, we show a function that randomizes friction and actuator gain/bias."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "h8mhzKjHQuoL"
-      },
-      "outputs": [],
-      "source": [
-        "def domain_randomize(sys, rng):\n",
-        "  \"\"\"Randomizes the mjx.Model.\"\"\"\n",
-        "  @jax.vmap\n",
-        "  def rand(rng):\n",
-        "    _, key = jax.random.split(rng, 2)\n",
-        "    # friction\n",
-        "    friction = jax.random.uniform(key, (1,), minval=0.6, maxval=1.4)\n",
-        "    friction = sys.geom_friction.at[:, 0].set(friction)\n",
-        "    # actuator\n",
-        "    _, key = jax.random.split(key, 2)\n",
-        "    gain_range = (-10, -5)\n",
-        "    param = jax.random.uniform(\n",
-        "        key, (1,), minval=gain_range[0], maxval=gain_range[1]\n",
-        "    ) + sys.actuator_gainprm[:, 0]\n",
-        "    gain = sys.actuator_gainprm.at[:, 0].set(param)\n",
-        "    bias = sys.actuator_biasprm.at[:, 1].set(-param)\n",
-        "    return friction, gain, bias\n",
-        "\n",
-        "  friction, gain, bias = rand(rng)\n",
-        "\n",
-        "  in_axes = jax.tree_map(lambda x: None, sys)\n",
-        "  in_axes = in_axes.tree_replace({\n",
-        "      'geom_friction': 0,\n",
-        "      'actuator_gainprm': 0,\n",
-        "      'actuator_biasprm': 0,\n",
-        "  })\n",
-        "\n",
-        "  sys = sys.tree_replace({\n",
-        "      'geom_friction': friction,\n",
-        "      'actuator_gainprm': gain,\n",
-        "      'actuator_biasprm': bias,\n",
-        "  })\n",
-        "\n",
-        "  return sys, in_axes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gnsZo-GWSYYj"
-      },
-      "source": [
-        "If we wanted 10 environments with randomized friction and actuator params, we can call `domain_randomize`, which returns a batched `mjModel` along with a dictionary specifying the axes that are batched."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1K45Kp2ASV9s"
-      },
-      "outputs": [],
-      "source": [
-        "rng = jax.random.PRNGKey(0)\n",
-        "rng = jax.random.split(rng, 10)\n",
-        "batched_sys, _ = domain_randomize(env.sys, rng)\n",
-        "\n",
-        "print('Single env friction shape: ', env.sys.geom_friction.shape)\n",
-        "print('Batched env friction shape: ', batched_sys.geom_friction.shape)\n",
-        "\n",
-        "print('Friction on geom 0: ', env.sys.geom_friction[0, 0])\n",
-        "print('Random frictions on geom 0: ', batched_sys.geom_friction[:, 0, 0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "efnxNOnpQFuC"
-      },
-      "source": [
-        "## Quadruped Env\n",
-        "\n",
-        "Let's define a quadruped environment that takes advantage of the domain randomization function. Here we use the [Barkour v0 Quadruped](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_v0) and an environment that trains a joystick policy."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "y79PoJOCIl-O"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Barkour v0 Quadruped Env\n",
-        "\n",
-        "def get_config():\n",
-        "  \"\"\"Returns reward config for barkour quadruped environment.\"\"\"\n",
-        "\n",
-        "  def get_default_rewards_config():\n",
-        "    default_config = config_dict.ConfigDict(\n",
-        "        dict(\n",
-        "            # The coefficients for all reward terms used for training. All\n",
-        "            # physical quantities are in SI units, if no otherwise specified,\n",
-        "            # i.e. joint positions are in rad, positions are measured in meters,\n",
-        "            # torques in Nm, and time in seconds, and forces in Newtons.\n",
-        "            scales=config_dict.ConfigDict(\n",
-        "                dict(\n",
-        "                    # Tracking rewards are computed using exp(-delta^2/sigma)\n",
-        "                    # sigma can be a hyperparameters to tune.\n",
-        "                    # Track the base x-y velocity (no z-velocity tracking.)\n",
-        "                    tracking_lin_vel=1.5,\n",
-        "                    # Track the angular velocity along z-axis, i.e. yaw rate.\n",
-        "                    tracking_ang_vel=0.8,\n",
-        "                    # Below are regularization terms, we roughly divide the\n",
-        "                    # terms to base state regularizations, joint\n",
-        "                    # regularizations, and other behavior regularizations.\n",
-        "                    # Penalize the base velocity in z direction, L2 penalty.\n",
-        "                    lin_vel_z=-2.0,\n",
-        "                    # Penalize the base roll and pitch rate. L2 penalty.\n",
-        "                    ang_vel_xy=-0.05,\n",
-        "                    # Penalize non-zero roll and pitch angles. L2 penalty.\n",
-        "                    orientation=-5.0,\n",
-        "                    # L2 regularization of joint torques, |tau|^2.\n",
-        "                    # torques=-0.0002,\n",
-        "                    torques=-0.002,\n",
-        "                    # Penalize the change in the action and encourage smooth\n",
-        "                    # actions. L2 regularization |action - last_action|^2\n",
-        "                    action_rate=-0.1,\n",
-        "                    # Encourage long swing steps.  However, it does not\n",
-        "                    # encourage high clearances.\n",
-        "                    feet_air_time=0.2,\n",
-        "                    # Encourage no motion at zero command, L2 regularization\n",
-        "                    # |q - q_default|^2.\n",
-        "                    stand_still=-0.5,\n",
-        "                    # Early termination penalty.\n",
-        "                    termination=-1.0,\n",
-        "                    # Penalizing foot slipping on the ground.\n",
-        "                    foot_slip=-0.1,\n",
-        "                )\n",
-        "            ),\n",
-        "            # Tracking reward = exp(-error^2/sigma).\n",
-        "            tracking_sigma=0.25,\n",
-        "        )\n",
-        "    )\n",
-        "    return default_config\n",
-        "\n",
-        "  default_config = config_dict.ConfigDict(\n",
-        "      dict(rewards=get_default_rewards_config(),))\n",
-        "\n",
-        "  return default_config\n",
-        "\n",
-        "\n",
-        "class BarkourEnv(MjxEnv):\n",
-        "  \"\"\"Environment for training the barkour quadruped joystick policy in MJX.\"\"\"\n",
-        "\n",
-        "  def __init__(\n",
-        "      self,\n",
-        "      obs_noise: float = 0.05,\n",
-        "      action_scale: float=0.3,\n",
-        "      **kwargs,\n",
-        "  ):\n",
-        "    path = epath.Path(epath.resource_path('mujoco')) / (\n",
-        "        'mjx/benchmark/model/barkour_v0/assets'\n",
-        "    )\n",
-        "    mj_model = mujoco.MjModel.from_xml_path(\n",
-        "        (path / 'barkour_v0_mjx.xml').as_posix())\n",
-        "    mj_model.opt.solver = mujoco.mjtSolver.mjSOL_CG\n",
-        "    mj_model.opt.iterations = 4\n",
-        "    mj_model.opt.ls_iterations = 6\n",
-        "\n",
-        "    physics_steps_per_control_step = 10\n",
-        "    kwargs['physics_steps_per_control_step'] = kwargs.get(\n",
-        "        'physics_steps_per_control_step', physics_steps_per_control_step)\n",
-        "    super().__init__(mj_model=mj_model, **kwargs)\n",
-        "\n",
-        "    self.torso_idx = 1\n",
-        "    self._action_scale = action_scale\n",
-        "    self._obs_noise = obs_noise\n",
-        "    self._reset_horizon = 500\n",
-        "    self._feet_index = jp.array([3, 6, 9, 12])\n",
-        "    # local positions for each foot\n",
-        "    self._feet_pos = jp.array([\n",
-        "        [-0.191284, -0.0191638, 0.013],\n",
-        "        [-0.191284, -0.0191638, -0.013],\n",
-        "        [-0.191284, -0.0191638, 0.013],\n",
-        "        [-0.191284, -0.0191638, -0.013],\n",
-        "    ])\n",
-        "    self._init_q = mj_model.keyframe('standing').qpos\n",
-        "    self._default_ap_pose = mj_model.keyframe('standing').qpos[7:]\n",
-        "    self.reward_config = get_config()\n",
-        "    self.lowers = self._default_ap_pose - jp.array([0.2, 0.8, 0.8] * 4)\n",
-        "    self.uppers = self._default_ap_pose + jp.array([0.2, 0.8, 0.8] * 4)\n",
-        "\n",
-        "  def sample_command(self, rng: jax.Array) -> jax.Array:\n",
-        "    lin_vel_x = [-0.6, 1.0]  # min max [m/s]\n",
-        "    lin_vel_y = [-0.8, 0.8]  # min max [m/s]\n",
-        "    ang_vel_yaw = [-0.7, 0.7]  # min max [rad/s]\n",
-        "\n",
-        "    _, key1, key2, key3 = jax.random.split(rng, 4)\n",
-        "    lin_vel_x = jax.random.uniform(\n",
-        "        key1, (1,), minval=lin_vel_x[0], maxval=lin_vel_x[1]\n",
-        "    )\n",
-        "    lin_vel_y = jax.random.uniform(\n",
-        "        key2, (1,), minval=lin_vel_y[0], maxval=lin_vel_y[1]\n",
-        "    )\n",
-        "    ang_vel_yaw = jax.random.uniform(\n",
-        "        key3, (1,), minval=ang_vel_yaw[0], maxval=ang_vel_yaw[1]\n",
-        "    )\n",
-        "    new_cmd = jp.array([lin_vel_x[0], lin_vel_y[0], ang_vel_yaw[0]])\n",
-        "    return new_cmd\n",
-        "\n",
-        "  def reset(self, rng: jax.Array) -> State:\n",
-        "    rng, key = jax.random.split(rng)\n",
-        "\n",
-        "    qpos = jp.array(self._init_q)\n",
-        "    qvel = jp.zeros(self.model.nv)\n",
-        "    new_cmd = self.sample_command(key)\n",
-        "    data = self.pipeline_init(qpos, qvel)\n",
-        "\n",
-        "    state_info = {\n",
-        "        'rng': rng,\n",
-        "        'last_act': jp.zeros(12),\n",
-        "        'last_vel': jp.zeros(12),\n",
-        "        'last_contact_buffer': jp.zeros((20, 4), dtype=bool),\n",
-        "        'command': new_cmd,\n",
-        "        'last_contact': jp.zeros(4, dtype=bool),\n",
-        "        'feet_air_time': jp.zeros(4),\n",
-        "        'obs_history': jp.zeros(15 * 31),\n",
-        "        'reward_tuple': {\n",
-        "            'tracking_lin_vel': 0.0,\n",
-        "            'tracking_ang_vel': 0.0,\n",
-        "            'lin_vel_z': 0.0,\n",
-        "            'ang_vel_xy': 0.0,\n",
-        "            'orientation': 0.0,\n",
-        "            'torque': 0.0,\n",
-        "            'action_rate': 0.0,\n",
-        "            'stand_still': 0.0,\n",
-        "            'feet_air_time': 0.0,\n",
-        "            'foot_slip': 0.0,\n",
-        "        },\n",
-        "        'step': 0,\n",
-        "    }\n",
-        "\n",
-        "    x, xd = self._pos_vel(data)\n",
-        "    obs = self._get_obs(data.qpos, x, xd, state_info)\n",
-        "    reward, done = jp.zeros(2)\n",
-        "    metrics = {'total_dist': 0.0}\n",
-        "    for k in state_info['reward_tuple']:\n",
-        "      metrics[k] = state_info['reward_tuple'][k]\n",
-        "    state = State(data, obs, reward, done, metrics, state_info)\n",
-        "    return state\n",
-        "\n",
-        "  def step(self, state: State, action: jax.Array) -> State:\n",
-        "    rng, rng_noise, cmd_rng = jax.random.split(\n",
-        "        state.info['rng'], 3\n",
-        "    )\n",
-        "\n",
-        "    # physics step\n",
-        "    cur_action = jp.array(action)\n",
-        "    action = action[:12] * self._action_scale\n",
-        "    motor_targets = jp.clip(\n",
-        "        action + self._default_ap_pose, self.lowers, self.uppers\n",
-        "    )\n",
-        "    data = self.pipeline_step(state.pipeline_state, motor_targets)\n",
-        "\n",
-        "    # observation data\n",
-        "    x, xd = self._pos_vel(data)\n",
-        "    obs = self._get_obs(data.qpos, x, xd, state.info)\n",
-        "    obs_noise = self._obs_noise * jax.random.uniform(\n",
-        "        rng_noise, obs.shape, minval=-1, maxval=1)\n",
-        "    qpos, qvel = data.qpos, data.qvel\n",
-        "    joint_angles = qpos[7:]\n",
-        "    joint_vel = qvel[6:]\n",
-        "\n",
-        "    # foot contact data based on z-position\n",
-        "    foot_contact = 0.017 - self._get_feet_pos_vel(x, xd)[0][:, 2]\n",
-        "    contact = foot_contact > -1e-3  # a mm or less off the floor\n",
-        "    contact_filt_mm = jp.logical_or(contact, state.info['last_contact'])\n",
-        "    contact_filt_cm = jp.logical_or(\n",
-        "        foot_contact > -1e-2, state.info['last_contact']\n",
-        "    )\n",
-        "    first_contact = (state.info['feet_air_time'] > 0) * (contact_filt_mm)\n",
-        "    state.info['feet_air_time'] += self.dt\n",
-        "\n",
-        "    # reward\n",
-        "    reward_tuple = {\n",
-        "        'tracking_lin_vel': (\n",
-        "            self._reward_tracking_lin_vel(state.info['command'], x, xd)\n",
-        "            * self.reward_config.rewards.scales.tracking_lin_vel\n",
-        "        ),\n",
-        "        'tracking_ang_vel': (\n",
-        "            self._reward_tracking_ang_vel(state.info['command'], x, xd)\n",
-        "            * self.reward_config.rewards.scales.tracking_ang_vel\n",
-        "        ),\n",
-        "        'lin_vel_z': (\n",
-        "            self._reward_lin_vel_z(xd)\n",
-        "            * self.reward_config.rewards.scales.lin_vel_z\n",
-        "        ),\n",
-        "        'ang_vel_xy': (\n",
-        "            self._reward_ang_vel_xy(xd)\n",
-        "            * self.reward_config.rewards.scales.ang_vel_xy\n",
-        "        ),\n",
-        "        'orientation': (\n",
-        "            self._reward_orientation(x)\n",
-        "            * self.reward_config.rewards.scales.orientation\n",
-        "        ),\n",
-        "        'torque': (\n",
-        "            self._reward_torques(data.qfrc_actuator)\n",
-        "            * self.reward_config.rewards.scales.torques\n",
-        "        ),\n",
-        "        'action_rate': (\n",
-        "            self._reward_action_rate(cur_action, state.info['last_act'])\n",
-        "            * self.reward_config.rewards.scales.action_rate\n",
-        "        ),\n",
-        "        'stand_still': (\n",
-        "            self._reward_stand_still(\n",
-        "                state.info['command'], joint_angles, self._default_ap_pose\n",
-        "            )\n",
-        "            * self.reward_config.rewards.scales.stand_still\n",
-        "        ),\n",
-        "        'feet_air_time': (\n",
-        "            self._reward_feet_air_time(\n",
-        "                state.info['feet_air_time'],\n",
-        "                first_contact,\n",
-        "                state.info['command'],\n",
-        "            )\n",
-        "            * self.reward_config.rewards.scales.feet_air_time\n",
-        "        ),\n",
-        "        'foot_slip': (\n",
-        "            self._reward_foot_slip(x, xd, contact_filt_cm)\n",
-        "            * self.reward_config.rewards.scales.foot_slip\n",
-        "        ),\n",
-        "    }\n",
-        "    reward = sum(reward_tuple.values())\n",
-        "    reward = jp.clip(reward * self.dt, 0.0, 10000.0)\n",
-        "\n",
-        "    # state management\n",
-        "    state.info['last_act'] = cur_action\n",
-        "    state.info['last_vel'] = joint_vel\n",
-        "    state.info['feet_air_time'] *= ~contact_filt_mm\n",
-        "    state.info['last_contact'] = contact\n",
-        "    state.info['last_contact_buffer'] = jp.roll(\n",
-        "        state.info['last_contact_buffer'], 1, axis=0\n",
-        "    )\n",
-        "    state.info['last_contact_buffer'] = (\n",
-        "        state.info['last_contact_buffer'].at[0].set(contact)\n",
-        "    )\n",
-        "    state.info['reward_tuple'] = reward_tuple\n",
-        "    state.info['step'] += 1\n",
-        "    state.info.update(rng=rng)\n",
-        "\n",
-        "    # resetting logic if joint limits are reached or robot is falling\n",
-        "    done = 0.0\n",
-        "    up = jp.array([0.0, 0.0, 1.0])\n",
-        "    done = jp.where(jp.dot(math.rotate(up, x.rot[0]), up) < 0, 1.0, done)\n",
-        "    done = jp.where(jp.logical_or(\n",
-        "        jp.any(joint_angles < .98 * self.lowers),\n",
-        "        jp.any(joint_angles > .98 * self.uppers)), 1.0, done)\n",
-        "    done = jp.where(x.pos[self.torso_idx, 2] < 0.18, 1.0, done)\n",
-        "\n",
-        "    # termination reward\n",
-        "    reward += jp.where(\n",
-        "        (done == 1.0) & (state.info['step'] < self._reset_horizon),\n",
-        "        self.reward_config.rewards.scales.termination,\n",
-        "        0.0,\n",
-        "    )\n",
-        "\n",
-        "    # when done, sample new command if more than _reset_horizon timesteps\n",
-        "    # achieved\n",
-        "    state.info['command'] = jp.where(\n",
-        "        (done == 1.0) & (state.info['step'] > self._reset_horizon),\n",
-        "        self.sample_command(cmd_rng), state.info['command'])\n",
-        "    # reset the step counter when done\n",
-        "    state.info['step'] = jp.where(\n",
-        "        (done == 1.0) | (state.info['step'] > self._reset_horizon), 0,\n",
-        "        state.info['step']\n",
-        "    )\n",
-        "\n",
-        "    # log total displacement as a proxy metric\n",
-        "    state.metrics['total_dist'] = math.normalize(x.pos[self.torso_idx])[1]\n",
-        "    for k in state.info['reward_tuple'].keys():\n",
-        "      state.metrics[k] = state.info['reward_tuple'][k]\n",
-        "\n",
-        "    state = state.replace(\n",
-        "        pipeline_state=data, obs=obs + obs_noise, reward=reward,\n",
-        "        done=done)\n",
-        "    return state\n",
-        "\n",
-        "  def _get_obs(self, qpos: jax.Array, x: Transform, xd: Motion,\n",
-        "               state_info: Dict[str, Any]) -> jax.Array:\n",
-        "    # Get observations:\n",
-        "    # yaw_rate,  projected_gravity, command,  motor_angles, last_action\n",
-        "\n",
-        "    inv_base_orientation = math.quat_inv(x.rot[0])\n",
-        "    local_rpyrate = math.rotate(xd.ang[0], inv_base_orientation)\n",
-        "    cmd = state_info['command']\n",
-        "\n",
-        "    obs_list = []\n",
-        "    # yaw rate\n",
-        "    obs_list.append(jp.array([local_rpyrate[2]]) * 0.25)\n",
-        "    # projected gravity\n",
-        "    obs_list.append(\n",
-        "        math.rotate(jp.array([0.0, 0.0, -1.0]), inv_base_orientation))\n",
-        "    # command\n",
-        "    obs_list.append(cmd * jp.array([2.0, 2.0, 0.25]))\n",
-        "    # motor angles\n",
-        "    angles = qpos[7:19]\n",
-        "    obs_list.append(angles - self._default_ap_pose)\n",
-        "    # last action\n",
-        "    obs_list.append(state_info['last_act'])\n",
-        "\n",
-        "    obs = jp.clip(jp.concatenate(obs_list), -100.0, 100.0)\n",
-        "\n",
-        "    # stack observations through time\n",
-        "    single_obs_size = len(obs)\n",
-        "    state_info['obs_history'] = jp.roll(\n",
-        "        state_info['obs_history'], single_obs_size\n",
-        "    )\n",
-        "    state_info['obs_history'] = jp.array(\n",
-        "        state_info['obs_history']).at[:single_obs_size].set(obs)\n",
-        "    return state_info['obs_history']\n",
-        "\n",
-        "  # ------------ reward functions----------------\n",
-        "  def _reward_lin_vel_z(self, xd: Motion) -> jax.Array:\n",
-        "    # Penalize z axis base linear velocity\n",
-        "    return jp.square(xd.vel[0, 2])\n",
-        "\n",
-        "  def _reward_ang_vel_xy(self, xd: Motion) -> jax.Array:\n",
-        "    # Penalize xy axes base angular velocity\n",
-        "    return jp.sum(jp.square(xd.ang[0, :2]))\n",
-        "\n",
-        "  def _reward_orientation(self, x: Transform) -> jax.Array:\n",
-        "    # Penalize non flat base orientation\n",
-        "    up = jp.array([0.0, 0.0, 1.0])\n",
-        "    rot_up = math.rotate(up, x.rot[0])\n",
-        "    return jp.sum(jp.square(rot_up[:2]))\n",
-        "\n",
-        "  def _reward_torques(self, torques: jax.Array) -> jax.Array:\n",
-        "    # Penalize torques\n",
-        "    return jp.sqrt(jp.sum(jp.square(torques))) + jp.sum(jp.abs(torques))\n",
-        "\n",
-        "  def _reward_action_rate(\n",
-        "      self, act: jax.Array, last_act: jax.Array) -> jax.Array:\n",
-        "    # Penalize changes in actions\n",
-        "    return jp.sum(jp.square(act - last_act))\n",
-        "\n",
-        "  def _reward_tracking_lin_vel(\n",
-        "      self, commands: jax.Array, x: Transform, xd: Motion) -> jax.Array:\n",
-        "    # Tracking of linear velocity commands (xy axes)\n",
-        "    local_vel = math.rotate(xd.vel[0], math.quat_inv(x.rot[0]))\n",
-        "    lin_vel_error = jp.sum(jp.square(commands[:2] - local_vel[:2]))\n",
-        "    lin_vel_reward = jp.exp(\n",
-        "        -lin_vel_error / self.reward_config.rewards.tracking_sigma\n",
-        "    )\n",
-        "    return lin_vel_reward\n",
-        "\n",
-        "  def _reward_tracking_ang_vel(\n",
-        "      self, commands: jax.Array, x: Transform, xd: Motion) -> jax.Array:\n",
-        "    # Tracking of angular velocity commands (yaw)\n",
-        "    base_ang_vel = math.rotate(xd.ang[0], math.quat_inv(x.rot[0]))\n",
-        "    ang_vel_error = jp.square(commands[2] - base_ang_vel[2])\n",
-        "    return jp.exp(-ang_vel_error/self.reward_config.rewards.tracking_sigma)\n",
-        "\n",
-        "  def _reward_feet_air_time(\n",
-        "      self, air_time: jax.Array, first_contact: jax.Array,\n",
-        "      commands: jax.Array) -> jax.Array:\n",
-        "    # Reward air time.\n",
-        "    rew_air_time = jp.sum((air_time - 0.1) * first_contact)\n",
-        "    rew_air_time *= (\n",
-        "        math.normalize(commands[:2])[1] > 0.05\n",
-        "    )  # no reward for zero command\n",
-        "    return rew_air_time\n",
-        "\n",
-        "  def _reward_stand_still(\n",
-        "      self, commands: jax.Array, joint_angles: jax.Array,\n",
-        "      default_angles: jax.Array) -> jax.Array:\n",
-        "    # Penalize motion at zero commands\n",
-        "    return jp.sum(jp.abs(joint_angles - default_angles)) * (\n",
-        "        math.normalize(commands[:2])[1] < 0.1\n",
-        "    )\n",
-        "\n",
-        "  def _get_feet_pos_vel(\n",
-        "      self, x: Transform, xd: Motion) -> Tuple[jax.Array, jax.Array]:\n",
-        "    offset = Transform.create(pos=self._feet_pos)\n",
-        "    pos = x.take(self._feet_index).vmap().do(offset).pos\n",
-        "    vel = offset.vmap().do(xd.take(self._feet_index)).vel\n",
-        "    return pos, vel\n",
-        "\n",
-        "  def _reward_foot_slip(\n",
-        "      self, x: Transform, xd: Motion, contact_filt: jax.Array) -> jax.Array:\n",
-        "    # Get feet velocities\n",
-        "    _, foot_world_vel = self._get_feet_pos_vel(x, xd)\n",
-        "    # Penalize large feet velocity for feet that are in contact with the ground.\n",
-        "    return jp.sum(\n",
-        "        jp.square(foot_world_vel[:, :2]) * contact_filt.reshape((-1, 1))\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "envs.register_environment('barkour', BarkourEnv)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pi_yrcz-Qp3W"
-      },
-      "outputs": [],
-      "source": [
-        "env_name = 'barkour'\n",
-        "env = envs.get_environment(env_name)\n",
-        "\n",
-        "# re-instantiate the renderer\n",
-        "renderer = mujoco.Renderer(env.model)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nxaNFP9mA23H"
-      },
-      "source": [
-        "## Train Policy\n",
-        "\n",
-        "To train a policy with domain randomization, we pass in the domain randomization function into the brax train function; brax will call the domain randomization function when rolling out episodes. Training the quadruped takes about 14 minutes on a Tesla V100 GPU."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cHJCbESGA7Rk"
-      },
-      "outputs": [],
-      "source": [
-        "make_networks_factory = functools.partial(\n",
-        "    ppo_networks.make_ppo_networks,\n",
-        "        policy_hidden_layer_sizes=(128, 128, 128, 128))\n",
-        "train_fn = functools.partial(\n",
-        "      ppo.train,\n",
-        "      num_timesteps=60_000_000, num_evals=3, reward_scaling=1,\n",
-        "      episode_length=1000, normalize_observations=True,\n",
-        "      action_repeat=1, unroll_length=20, num_minibatches=8, gae_lambda=0.95,\n",
-        "      num_updates_per_batch=4, discounting=0.99, learning_rate=3e-4,\n",
-        "      entropy_cost=1e-2, num_envs=8192, batch_size=1024,\n",
-        "      network_factory=make_networks_factory,\n",
-        "      num_resets_per_eval=10,\n",
-        "      randomization_fn=domain_randomize, seed=0)\n",
-        "\n",
-        "\n",
-        "x_data = []\n",
-        "y_data = []\n",
-        "ydataerr = []\n",
-        "times = [datetime.now()]\n",
-        "max_y, min_y = 30, 0\n",
-        "\n",
-        "# Reset environments since internals may be overwritten by tracers from the\n",
-        "# domain randomization function.\n",
-        "env = envs.get_environment(env_name)\n",
-        "eval_env = envs.get_environment(env_name)\n",
-        "make_inference_fn, params, _= train_fn(environment=env,\n",
-        "                                       progress_fn=progress,\n",
-        "                                       eval_env=eval_env)\n",
-        "\n",
-        "print(f'time to jit: {times[1] - times[0]}')\n",
-        "print(f'time to train: {times[-1] - times[1]}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "8Yge-CGP5JoO"
-      },
-      "outputs": [],
-      "source": [
-        "# Save and reload params.\n",
-        "model_path = '/tmp/mjx_brax_quadruped_policy'\n",
-        "model.save_params(model_path, params)\n",
-        "params = model.load_params(model_path)\n",
-        "\n",
-        "inference_fn = make_inference_fn(params)\n",
-        "jit_inference_fn = jax.jit(inference_fn)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "L01IrN4oCIkC"
-      },
-      "source": [
-        "## Visualize Policy\n",
-        "\n",
-        "For the Barkour Quadruped, the joystick commands can be set through `x_vel`, `y_vel`, and `ang_vel`. `x_vel` and `y_vel` define the linear forward and sideways velocities with respect to the quadruped torso. `ang_vel` defines the angular velocity of the torso in the z direction."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VTbpEtXnEecd"
-      },
-      "outputs": [],
-      "source": [
-        "eval_env = envs.get_environment(env_name)\n",
-        "\n",
-        "jit_reset = jax.jit(eval_env.reset)\n",
-        "jit_step = jax.jit(eval_env.step)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "HRRN-8L-BivZ"
-      },
-      "outputs": [],
-      "source": [
-        "\n",
-        "# @markdown Commands **only used for Barkour Env**:\n",
-        "x_vel = 1.0  #@param {type: \"number\"}\n",
-        "y_vel = 0.0  #@param {type: \"number\"}\n",
-        "ang_vel = -0.5  #@param {type: \"number\"}\n",
-        "\n",
-        "the_command = jp.array([x_vel, y_vel, ang_vel])\n",
-        "\n",
-        "# initialize the state\n",
-        "rng = jax.random.PRNGKey(0)\n",
-        "state = jit_reset(rng)\n",
-        "state.info['command'] = the_command\n",
-        "rollout = [state]\n",
-        "images = [get_image(state, camera='track')]\n",
-        "\n",
-        "# grab a trajectory\n",
-        "n_steps = 500\n",
-        "render_every = 2\n",
-        "\n",
-        "for i in range(n_steps):\n",
-        "  act_rng, rng = jax.random.split(rng)\n",
-        "  ctrl, _ = jit_inference_fn(state.obs, act_rng)\n",
-        "  state = jit_step(state, ctrl)\n",
-        "  rollout.append(state)\n",
-        "  if i % render_every == 0:\n",
-        "    images.append(get_image(state, camera='track'))\n",
-        "\n",
-        "media.show_video(images, fps=1.0 / eval_env.dt / render_every)"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "gpuClass": "premium",
-      "gpuType": "V100",
-      "private_outputs": true,
-      "provenance": [
-        {
-          "file_id": "1brcF4_qCRS2ASc-QQw1rsEwl5IjzGvq2",
-          "timestamp": 1697763780236
-        }
-      ],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MpkYHwCqk7W-"
+   },
+   "source": [
+    "![MuJoCo banner](https://raw.githubusercontent.com/google-deepmind/mujoco/main/banner.png)\n",
+    "\n",
+    "# <h1><center>Tutorial  <a href=\"https://colab.research.google.com/github/google-deepmind/mujoco/blob/main/mjx/tutorial.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" width=\"140\" align=\"center\"/></a></center></h1>\n",
+    "\n",
+    "This notebook provides an introductory tutorial for [**MuJoCo XLA (MJX)**](https://github.com/google-deepmind/mujoco/blob/main/mjx), a JAX-based implementation of MuJoCo useful for RL training workloads.\n",
+    "\n",
+    "**A Colab runtime with GPU acceleration is required.** If you're using a CPU-only runtime, you can switch using the menu \"Runtime > Change runtime type\".\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xBSdkbmGN2K-"
+   },
+   "source": [
+    "### Copyright notice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_UbO9uhtBSX5"
+   },
+   "source": [
+    "> <p><small><small>Copyright 2023 DeepMind Technologies Limited.</small></p>\n",
+    "> <p><small><small>Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <a href=\"http://www.apache.org/licenses/LICENSE-2.0\">http://www.apache.org/licenses/LICENSE-2.0</a>.</small></small></p>\n",
+    "> <p><small><small>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</small></small></p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YvyGCsgSCxHQ"
+   },
+   "source": [
+    "# Install MuJoCo, MJX, and Brax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Xqo7pyX-n72M"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install mujoco\n",
+    "!pip install mujoco_mjx\n",
+    "!pip install brax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "IbZxYDxzoz5R"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Check if MuJoCo installation was successful\n",
+    "\n",
+    "# from google.colab import files\n",
+    "\n",
+    "import distutils.util\n",
+    "import os\n",
+    "import subprocess\n",
+    "if subprocess.run('nvidia-smi').returncode:\n",
+    "  raise RuntimeError(\n",
+    "      'Cannot communicate with GPU. '\n",
+    "      'Make sure you are using a GPU Colab runtime. '\n",
+    "      'Go to the Runtime menu and select Choose runtime type.')\n",
+    "\n",
+    "# Tell XLA to use Triton GEMM, this improves steps/sec by ~30% on some GPUs\n",
+    "xla_flags = os.environ.get('XLA_FLAGS', '')\n",
+    "xla_flags += ' --xla_gpu_triton_gemm_any=True'\n",
+    "os.environ['XLA_FLAGS'] = xla_flags\n",
+    "\n",
+    "try:\n",
+    "  print('Checking that the installation succeeded:')\n",
+    "  import mujoco\n",
+    "  mujoco.MjModel.from_xml_string('<mujoco/>')\n",
+    "except Exception as e:\n",
+    "  raise e from RuntimeError(\n",
+    "      'Something went wrong during installation. Check the shell output above '\n",
+    "      'for more information.\\n'\n",
+    "      'If using a hosted Colab runtime, make sure you enable GPU acceleration '\n",
+    "      'by going to the Runtime menu and selecting \"Choose runtime type\".')\n",
+    "\n",
+    "print('Installation successful.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "T5f4w3Kq2X14"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Import packages for plotting and creating graphics\n",
+    "import time\n",
+    "import itertools\n",
+    "import numpy as np\n",
+    "from typing import Callable, NamedTuple, Optional, Union, List\n",
+    "\n",
+    "# Graphics and plotting.\n",
+    "print('Installing mediapy:')\n",
+    "!command -v ffmpeg >/dev/null || (apt update && apt install -y ffmpeg)\n",
+    "!pip install -q mediapy\n",
+    "import mediapy as media\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# More legible printing from numpy.\n",
+    "np.set_printoptions(precision=3, suppress=True, linewidth=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ObF1UXrkb0Nd"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Import MuJoCo, MJX, and Brax\n",
+    "\n",
+    "\n",
+    "from datetime import datetime\n",
+    "import functools\n",
+    "from IPython.display import HTML\n",
+    "import jax\n",
+    "from jax import numpy as jp\n",
+    "import numpy as np\n",
+    "from typing import Any, Dict, Sequence, Tuple, Union\n",
+    "\n",
+    "from brax import base\n",
+    "from brax import envs\n",
+    "from brax import math\n",
+    "from brax.base import Base, Motion, Transform\n",
+    "from brax.envs.base import Env, PipelineEnv, State\n",
+    "from brax.mjx.base import State as MjxState\n",
+    "from brax.training.agents.ppo import train as ppo\n",
+    "from brax.training.agents.ppo import networks as ppo_networks\n",
+    "from brax.io import html, mjcf, model\n",
+    "\n",
+    "from etils import epath\n",
+    "from flax import struct\n",
+    "from matplotlib import pyplot as plt\n",
+    "import mediapy as media\n",
+    "from ml_collections import config_dict\n",
+    "import mujoco\n",
+    "from mujoco import mjx\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Nj4-Xmx4DFaq"
+   },
+   "source": [
+    "# Introduction to MJX\n",
+    "\n",
+    "MJX is an implementation of MuJoCo written in [JAX](https://jax.readthedocs.io/en/latest/index.html), enabling large batch training on GPU/TPU. In this notebook, we will demonstrate how to train RL policies with MJX.\n",
+    "\n",
+    "Before we get into hefty RL workloads, let's get started with a simpler example! The entrypoint into MJX is through MuJoCo, so first we load a MuJoCo model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bNus3mbbDz6a"
+   },
+   "outputs": [],
+   "source": [
+    "xml = \"\"\"\n",
+    "<mujoco>\n",
+    "  <worldbody>\n",
+    "    <light name=\"top\" pos=\"0 0 1\"/>\n",
+    "    <body name=\"box_and_sphere\" euler=\"0 0 -30\">\n",
+    "      <joint name=\"swing\" type=\"hinge\" axis=\"1 -1 0\" pos=\"-.2 -.2 -.2\"/>\n",
+    "      <geom name=\"red_box\" type=\"box\" size=\".2 .2 .2\" rgba=\"1 0 0 1\"/>\n",
+    "      <geom name=\"green_sphere\" pos=\".2 .2 .2\" size=\".1\" rgba=\"0 1 0 1\"/>\n",
+    "    </body>\n",
+    "  </worldbody>\n",
+    "</mujoco>\n",
+    "\"\"\"\n",
+    "\n",
+    "# Make model, data, and renderer\n",
+    "mj_model = mujoco.MjModel.from_xml_string(xml)\n",
+    "mj_data = mujoco.MjData(mj_model)\n",
+    "renderer = mujoco.Renderer(mj_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Po5oykJbFQbj"
+   },
+   "source": [
+    "Next we take the MuJoCo model and data, and place them on the GPU device using MJX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TSpoOWqeEC3P"
+   },
+   "outputs": [],
+   "source": [
+    "mjx_model = mjx.put_model(mj_model)\n",
+    "mjx_data = mjx.put_data(mj_model, mj_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6rxMMSs4OJJf"
+   },
+   "source": [
+    "Below, we print the `qpos` from MuJoCo and MJX. Notice that the `qpos` for the mjData is a numpy array living on the CPU, while the `qpos` for `mjx.Data` is a JAX Array living on the GPU device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ZOD582pfOLP-"
+   },
+   "outputs": [],
+   "source": [
+    "print(mj_data.qpos, type(mj_data.qpos))\n",
+    "print(mjx_data.qpos, type(mjx_data.qpos), mjx_data.qpos.devices())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZShF9-o_JLm3"
+   },
+   "source": [
+    "Let's run the simulation in MuJoCo and render the trajectory. This example is taken from the [MuJoCo tutorial](https://colab.sandbox.google.com/github/google-deepmind/mujoco/blob/main/python/tutorial.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HDlPlX05I3m-"
+   },
+   "outputs": [],
+   "source": [
+    "# enable joint visualization option:\n",
+    "scene_option = mujoco.MjvOption()\n",
+    "scene_option.flags[mujoco.mjtVisFlag.mjVIS_JOINT] = True\n",
+    "\n",
+    "duration = 3.8  # (seconds)\n",
+    "framerate = 60  # (Hz)\n",
+    "\n",
+    "frames = []\n",
+    "mujoco.mj_resetData(mj_model, mj_data)\n",
+    "while mj_data.time < duration:\n",
+    "  mujoco.mj_step(mj_model, mj_data)\n",
+    "  if len(frames) < mj_data.time * framerate:\n",
+    "    renderer.update_scene(mj_data, scene_option=scene_option)\n",
+    "    pixels = renderer.render()\n",
+    "    frames.append(pixels)\n",
+    "\n",
+    "# Simulate and display video.\n",
+    "media.show_video(frames, fps=framerate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m70b_RxBJOyd"
+   },
+   "source": [
+    "Now let's run the same exact simulation on the GPU device using MJX!\n",
+    "\n",
+    "In the example below, we use `mjx.step` instead of `mujoco.mj_step`, and we also [`jax.jit`](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) the `mjx.step` so that it runs efficiently on the GPU. After each step, we convert the `mjx.Data` back to `mjData` so that we can use the MuJoCo renderer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Pr29xq0-JRQv"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "jit_step = jax.jit(mjx.step)\n",
+    "\n",
+    "frames = []\n",
+    "mujoco.mj_resetData(mj_model, mj_data)\n",
+    "mjx_data = mjx.put_data(mj_model, mj_data)\n",
+    "while mjx_data.time < duration:\n",
+    "  mjx_data = jit_step(mjx_model, mjx_data)\n",
+    "  if len(frames) < mjx_data.time * framerate:\n",
+    "    mj_data = mjx.get_data(mj_model, mjx_data)\n",
+    "    renderer.update_scene(mj_data, scene_option=scene_option)\n",
+    "    pixels = renderer.render()\n",
+    "    frames.append(pixels)\n",
+    "\n",
+    "media.show_video(frames, fps=framerate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wXsQ4qO2KO3Q"
+   },
+   "source": [
+    "Running single threaded physics simulation on the GPU is not very [efficient](https://mujoco.readthedocs.io/en/stable/mjx.html#mjx-the-sharp-bits). The advantage with MJX is that we can run environments in parallel on a hardware accelerated device. Let's try it out!\n",
+    "\n",
+    "In the example below, we create 4096 copies of the `mjx.Data` and we run the `mjx.step` over the batched data. Since MJX is implemented in JAX, we take advantage of [`jax.vmap`](https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html) to run the `mjx.step` in parallel over all `mjx.Data`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rrdrcKRVK6w9"
+   },
+   "outputs": [],
+   "source": [
+    "rng = jax.random.PRNGKey(0)\n",
+    "rng = jax.random.split(rng, 4096)\n",
+    "batch = jax.vmap(lambda rng: mjx_data.replace(qpos=jax.random.uniform(rng, (1,))))(rng)\n",
+    "\n",
+    "jit_step = jax.jit(jax.vmap(mjx.step, in_axes=(None, 0)))\n",
+    "batch = jit_step(mjx_model, batch)\n",
+    "\n",
+    "print(batch.qpos)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "x4lL220cOj0q"
+   },
+   "source": [
+    "We can copy the batched `mjx.Data` back to MuJoCo like we did before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Jtz7j1PDOnw5"
+   },
+   "outputs": [],
+   "source": [
+    "batched_mj_data = mjx.get_data(mj_model, batch)\n",
+    "print([d.qpos for d in batched_mj_data])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RAv6WUVUm78k"
+   },
+   "source": [
+    "# Training a Policy with MJX\n",
+    "\n",
+    "Running large batch physics simulation is useful for training RL policies. Here we demonstrate training RL policies with MJX using the RL library from [Brax](https://github.com/google/brax).\n",
+    "\n",
+    "Below, we implement the classic Humanoid environment using MJX and Brax. We inherit from the `MjxEnv` implementation in Brax so that we can step the physics with MJX while training with Brax RL implementations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mtGMYNLE3QJN"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Humanoid Env\n",
+    "\n",
+    "class Humanoid(PipelineEnv):\n",
+    "\n",
+    "  def __init__(\n",
+    "      self,\n",
+    "      forward_reward_weight=1.25,\n",
+    "      ctrl_cost_weight=0.1,\n",
+    "      healthy_reward=5.0,\n",
+    "      terminate_when_unhealthy=True,\n",
+    "      healthy_z_range=(1.0, 2.0),\n",
+    "      reset_noise_scale=1e-2,\n",
+    "      exclude_current_positions_from_observation=True,\n",
+    "      **kwargs,\n",
+    "  ):\n",
+    "    path = epath.Path(epath.resource_path('mujoco')) / (\n",
+    "        'mjx/test_data/humanoid'\n",
+    "    )\n",
+    "    mj_model = mujoco.MjModel.from_xml_path(\n",
+    "        (path / 'humanoid.xml').as_posix())\n",
+    "    mj_model.opt.solver = mujoco.mjtSolver.mjSOL_CG\n",
+    "    mj_model.opt.iterations = 6\n",
+    "    mj_model.opt.ls_iterations = 6\n",
+    "\n",
+    "    sys = mjcf.load_model(mj_model)\n",
+    "\n",
+    "    physics_steps_per_control_step = 5\n",
+    "    kwargs['n_frames'] = kwargs.get(\n",
+    "        'n_frames', physics_steps_per_control_step)\n",
+    "    kwargs['backend'] = 'mjx'\n",
+    "\n",
+    "    super().__init__(sys, **kwargs)\n",
+    "\n",
+    "    self._forward_reward_weight = forward_reward_weight\n",
+    "    self._ctrl_cost_weight = ctrl_cost_weight\n",
+    "    self._healthy_reward = healthy_reward\n",
+    "    self._terminate_when_unhealthy = terminate_when_unhealthy\n",
+    "    self._healthy_z_range = healthy_z_range\n",
+    "    self._reset_noise_scale = reset_noise_scale\n",
+    "    self._exclude_current_positions_from_observation = (\n",
+    "        exclude_current_positions_from_observation\n",
+    "    )\n",
+    "\n",
+    "  def reset(self, rng: jp.ndarray) -> State:\n",
+    "    \"\"\"Resets the environment to an initial state.\"\"\"\n",
+    "    rng, rng1, rng2 = jax.random.split(rng, 3)\n",
+    "\n",
+    "    low, hi = -self._reset_noise_scale, self._reset_noise_scale\n",
+    "    qpos = self.sys.qpos0 + jax.random.uniform(\n",
+    "        rng1, (self.sys.nq,), minval=low, maxval=hi\n",
+    "    )\n",
+    "    qvel = jax.random.uniform(\n",
+    "        rng2, (self.sys.nv,), minval=low, maxval=hi\n",
+    "    )\n",
+    "\n",
+    "    data = self.pipeline_init(qpos, qvel)\n",
+    "\n",
+    "    obs = self._get_obs(data, jp.zeros(self.sys.nu))\n",
+    "    reward, done, zero = jp.zeros(3)\n",
+    "    metrics = {\n",
+    "        'forward_reward': zero,\n",
+    "        'reward_linvel': zero,\n",
+    "        'reward_quadctrl': zero,\n",
+    "        'reward_alive': zero,\n",
+    "        'x_position': zero,\n",
+    "        'y_position': zero,\n",
+    "        'distance_from_origin': zero,\n",
+    "        'x_velocity': zero,\n",
+    "        'y_velocity': zero,\n",
+    "    }\n",
+    "    return State(data, obs, reward, done, metrics)\n",
+    "\n",
+    "  def step(self, state: State, action: jp.ndarray) -> State:\n",
+    "    \"\"\"Runs one timestep of the environment's dynamics.\"\"\"\n",
+    "    data0 = state.pipeline_state\n",
+    "    data = self.pipeline_step(data0, action)\n",
+    "\n",
+    "    com_before = data0.subtree_com[1]\n",
+    "    com_after = data.subtree_com[1]\n",
+    "    velocity = (com_after - com_before) / self.dt\n",
+    "    forward_reward = self._forward_reward_weight * velocity[0]\n",
+    "\n",
+    "    min_z, max_z = self._healthy_z_range\n",
+    "    is_healthy = jp.where(data.q[2] < min_z, 0.0, 1.0)\n",
+    "    is_healthy = jp.where(data.q[2] > max_z, 0.0, is_healthy)\n",
+    "    if self._terminate_when_unhealthy:\n",
+    "      healthy_reward = self._healthy_reward\n",
+    "    else:\n",
+    "      healthy_reward = self._healthy_reward * is_healthy\n",
+    "\n",
+    "    ctrl_cost = self._ctrl_cost_weight * jp.sum(jp.square(action))\n",
+    "\n",
+    "    obs = self._get_obs(data, action)\n",
+    "    reward = forward_reward + healthy_reward - ctrl_cost\n",
+    "    done = 1.0 - is_healthy if self._terminate_when_unhealthy else 0.0\n",
+    "    state.metrics.update(\n",
+    "        forward_reward=forward_reward,\n",
+    "        reward_linvel=forward_reward,\n",
+    "        reward_quadctrl=-ctrl_cost,\n",
+    "        reward_alive=healthy_reward,\n",
+    "        x_position=com_after[0],\n",
+    "        y_position=com_after[1],\n",
+    "        distance_from_origin=jp.linalg.norm(com_after),\n",
+    "        x_velocity=velocity[0],\n",
+    "        y_velocity=velocity[1],\n",
+    "    )\n",
+    "\n",
+    "    return state.replace(\n",
+    "        pipeline_state=data, obs=obs, reward=reward, done=done\n",
+    "    )\n",
+    "\n",
+    "  def _get_obs(\n",
+    "      self, data: mjx.Data, action: jp.ndarray\n",
+    "  ) -> jp.ndarray:\n",
+    "    \"\"\"Observes humanoid body position, velocities, and angles.\"\"\"\n",
+    "    position = data.qpos\n",
+    "    if self._exclude_current_positions_from_observation:\n",
+    "      position = position[2:]\n",
+    "\n",
+    "    # external_contact_forces are excluded\n",
+    "    return jp.concatenate([\n",
+    "        position,\n",
+    "        data.qvel,\n",
+    "        data.cinert[1:].ravel(),\n",
+    "        data.cvel[1:].ravel(),\n",
+    "        data.qfrc_actuator,\n",
+    "    ])\n",
+    "\n",
+    "\n",
+    "envs.register_environment('humanoid', Humanoid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "P1K6IznI2y83"
+   },
+   "source": [
+    "## Visualize a Rollout\n",
+    "\n",
+    "Let's instantiate the environment and visualize a short rollout.\n",
+    "\n",
+    "NOTE: Since episodes terminates early if the torso is below the healthy z-range, the only relevant contacts for this task are between the feet and the plane. We turn off other contacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EhKLFK54C1CH"
+   },
+   "outputs": [],
+   "source": [
+    "# instantiate the environment\n",
+    "env_name = 'humanoid'\n",
+    "env = envs.get_environment(env_name)\n",
+    "\n",
+    "# define the jit reset/step functions\n",
+    "jit_reset = jax.jit(env.reset)\n",
+    "jit_step = jax.jit(env.step)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ph8u-v2Q2xLS"
+   },
+   "outputs": [],
+   "source": [
+    "# initialize the state\n",
+    "state = jit_reset(jax.random.PRNGKey(0))\n",
+    "rollout = [state.pipeline_state]\n",
+    "\n",
+    "# grab a trajectory\n",
+    "for i in range(10):\n",
+    "  ctrl = -0.1 * jp.ones(env.sys.nu)\n",
+    "  state = jit_step(state, ctrl)\n",
+    "  rollout.append(state.pipeline_state)\n",
+    "\n",
+    "media.show_video(env.render(rollout, camera='side'), fps=1.0 / env.dt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BQDG6NQ1CbZD"
+   },
+   "source": [
+    "## Train Humanoid Policy\n",
+    "\n",
+    "Let's now train a policy with PPO to make the Humanoid run forwards. Training takes about 6 minutes on a Tesla A100 GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xLiddQYPApBw"
+   },
+   "outputs": [],
+   "source": [
+    "train_fn = functools.partial(\n",
+    "    ppo.train, num_timesteps=30_000_000, num_evals=5, reward_scaling=0.1,\n",
+    "    episode_length=1000, normalize_observations=True, action_repeat=1,\n",
+    "    unroll_length=10, num_minibatches=32, num_updates_per_batch=8,\n",
+    "    discounting=0.97, learning_rate=3e-4, entropy_cost=1e-3, num_envs=2048,\n",
+    "    batch_size=1024, seed=0)\n",
+    "\n",
+    "\n",
+    "x_data = []\n",
+    "y_data = []\n",
+    "ydataerr = []\n",
+    "times = [datetime.now()]\n",
+    "\n",
+    "max_y, min_y = 13000, 0\n",
+    "def progress(num_steps, metrics):\n",
+    "  times.append(datetime.now())\n",
+    "  x_data.append(num_steps)\n",
+    "  y_data.append(metrics['eval/episode_reward'])\n",
+    "  ydataerr.append(metrics['eval/episode_reward_std'])\n",
+    "\n",
+    "  plt.xlim([0, train_fn.keywords['num_timesteps'] * 1.25])\n",
+    "  plt.ylim([min_y, max_y])\n",
+    "\n",
+    "  plt.xlabel('# environment steps')\n",
+    "  plt.ylabel('reward per episode')\n",
+    "  plt.title(f'y={y_data[-1]:.3f}')\n",
+    "\n",
+    "  plt.errorbar(\n",
+    "      x_data, y_data, yerr=ydataerr)\n",
+    "  plt.show()\n",
+    "\n",
+    "make_inference_fn, params, _= train_fn(environment=env, progress_fn=progress)\n",
+    "\n",
+    "print(f'time to jit: {times[1] - times[0]}')\n",
+    "print(f'time to train: {times[-1] - times[1]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YYIch0HEApBx"
+   },
+   "source": [
+    "<!-- ## Save and Load Policy -->\n",
+    "\n",
+    "We can save and load the policy using the brax model API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Z8gI6qH6ApBx"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Save Model\n",
+    "model_path = '/tmp/mjx_brax_policy'\n",
+    "model.save_params(model_path, params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h4reaWgxApBx"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Load Model and Define Inference Function\n",
+    "params = model.load_params(model_path)\n",
+    "\n",
+    "inference_fn = make_inference_fn(params)\n",
+    "jit_inference_fn = jax.jit(inference_fn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0G357XIfApBy"
+   },
+   "source": [
+    "## Visualize Policy\n",
+    "\n",
+    "Finally we can visualize the policy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "osYasMw4ApBy"
+   },
+   "outputs": [],
+   "source": [
+    "eval_env = envs.get_environment(env_name)\n",
+    "\n",
+    "jit_reset = jax.jit(eval_env.reset)\n",
+    "jit_step = jax.jit(eval_env.step)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d-UhypudApBy"
+   },
+   "outputs": [],
+   "source": [
+    "# initialize the state\n",
+    "rng = jax.random.PRNGKey(0)\n",
+    "state = jit_reset(rng)\n",
+    "rollout = [state.pipeline_state]\n",
+    "\n",
+    "# grab a trajectory\n",
+    "n_steps = 500\n",
+    "render_every = 2\n",
+    "\n",
+    "for i in range(n_steps):\n",
+    "  act_rng, rng = jax.random.split(rng)\n",
+    "  ctrl, _ = jit_inference_fn(state.obs, act_rng)\n",
+    "  state = jit_step(state, ctrl)\n",
+    "  rollout.append(state.pipeline_state)\n",
+    "\n",
+    "  if state.done:\n",
+    "    break\n",
+    "\n",
+    "media.show_video(env.render(rollout[::render_every], camera='side'), fps=1.0 / env.dt / render_every)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zR-heox6LARK"
+   },
+   "source": [
+    "# MJX Policy in MuJoCo\n",
+    "\n",
+    "We can also perform the physics step using the original MuJoCo python bindings to show that the policy trained in MJX works in MuJoCo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "w6ixFi4dApBy"
+   },
+   "outputs": [],
+   "source": [
+    "mj_model = eval_env.sys.mj_model\n",
+    "mj_data = mujoco.MjData(mj_model)\n",
+    "\n",
+    "renderer = mujoco.Renderer(mj_model)\n",
+    "ctrl = jp.zeros(mj_model.nu)\n",
+    "\n",
+    "images = []\n",
+    "for i in range(n_steps):\n",
+    "  act_rng, rng = jax.random.split(rng)\n",
+    "\n",
+    "  obs = eval_env._get_obs(mjx.put_data(mj_model, mj_data), ctrl)\n",
+    "  ctrl, _ = jit_inference_fn(obs, act_rng)\n",
+    "\n",
+    "  mj_data.ctrl = ctrl\n",
+    "  for _ in range(eval_env._n_frames):\n",
+    "    mujoco.mj_step(mj_model, mj_data)  # Physics step using MuJoCo mj_step.\n",
+    "\n",
+    "  if i % render_every == 0:\n",
+    "    renderer.update_scene(mj_data, camera='side')\n",
+    "    images.append(renderer.render())\n",
+    "\n",
+    "media.show_video(images, fps=1.0 / eval_env.dt / render_every)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "65mIPj6DQNNa"
+   },
+   "source": [
+    "# Training a Policy with Domain Randomization\n",
+    "\n",
+    "We might also want to include randomization over certain `mjModel` parameters while training a policy. In MJX, we can easily create a batch of environments with randomized values populated in `mjx.Model`. Below, we show a function that randomizes friction and actuator gain/bias."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h8mhzKjHQuoL"
+   },
+   "outputs": [],
+   "source": [
+    "def domain_randomize(sys, rng):\n",
+    "  \"\"\"Randomizes the mjx.Model.\"\"\"\n",
+    "  @jax.vmap\n",
+    "  def rand(rng):\n",
+    "    _, key = jax.random.split(rng, 2)\n",
+    "    # friction\n",
+    "    friction = jax.random.uniform(key, (1,), minval=0.6, maxval=1.4)\n",
+    "    friction = sys.geom_friction.at[:, 0].set(friction)\n",
+    "    # actuator\n",
+    "    _, key = jax.random.split(key, 2)\n",
+    "    gain_range = (-5, 5)\n",
+    "    param = jax.random.uniform(\n",
+    "        key, (1,), minval=gain_range[0], maxval=gain_range[1]\n",
+    "    ) + sys.actuator_gainprm[:, 0]\n",
+    "    gain = sys.actuator_gainprm.at[:, 0].set(param)\n",
+    "    bias = sys.actuator_biasprm.at[:, 1].set(-param)\n",
+    "    return friction, gain, bias\n",
+    "\n",
+    "  friction, gain, bias = rand(rng)\n",
+    "\n",
+    "  in_axes = jax.tree_map(lambda x: None, sys)\n",
+    "  in_axes = in_axes.tree_replace({\n",
+    "      'geom_friction': 0,\n",
+    "      'actuator_gainprm': 0,\n",
+    "      'actuator_biasprm': 0,\n",
+    "  })\n",
+    "\n",
+    "  sys = sys.tree_replace({\n",
+    "      'geom_friction': friction,\n",
+    "      'actuator_gainprm': gain,\n",
+    "      'actuator_biasprm': bias,\n",
+    "  })\n",
+    "\n",
+    "  return sys, in_axes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gnsZo-GWSYYj"
+   },
+   "source": [
+    "If we wanted 10 environments with randomized friction and actuator params, we can call `domain_randomize`, which returns a batched `mjx.Model` along with a dictionary specifying the axes that are batched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1K45Kp2ASV9s"
+   },
+   "outputs": [],
+   "source": [
+    "rng = jax.random.PRNGKey(0)\n",
+    "rng = jax.random.split(rng, 10)\n",
+    "batched_sys, _ = domain_randomize(env.sys, rng)\n",
+    "\n",
+    "print('Single env friction shape: ', env.sys.geom_friction.shape)\n",
+    "print('Batched env friction shape: ', batched_sys.geom_friction.shape)\n",
+    "\n",
+    "print('Friction on geom 0: ', env.sys.geom_friction[0, 0])\n",
+    "print('Random frictions on geom 0: ', batched_sys.geom_friction[:, 0, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "efnxNOnpQFuC"
+   },
+   "source": [
+    "## Quadruped Env\n",
+    "\n",
+    "Let's define a quadruped environment that takes advantage of the domain randomization function. Here we use the [Barkour vb Quadruped](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_vb) from [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie). We implement an environment that trains a joystick policy with Brax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VfyK73gtRXid"
+   },
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/google-deepmind/mujoco_menagerie"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "y79PoJOCIl-O"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Barkour vb Quadruped Env\n",
+    "\n",
+    "def get_config():\n",
+    "  \"\"\"Returns reward config for barkour quadruped environment.\"\"\"\n",
+    "\n",
+    "  def get_default_rewards_config():\n",
+    "    default_config = config_dict.ConfigDict(\n",
+    "        dict(\n",
+    "            # The coefficients for all reward terms used for training. All\n",
+    "            # physical quantities are in SI units, if no otherwise specified,\n",
+    "            # i.e. joint positions are in rad, positions are measured in meters,\n",
+    "            # torques in Nm, and time in seconds, and forces in Newtons.\n",
+    "            scales=config_dict.ConfigDict(\n",
+    "                dict(\n",
+    "                    # Tracking rewards are computed using exp(-delta^2/sigma)\n",
+    "                    # sigma can be a hyperparameters to tune.\n",
+    "                    # Track the base x-y velocity (no z-velocity tracking.)\n",
+    "                    tracking_lin_vel=1.5,\n",
+    "                    # Track the angular velocity along z-axis, i.e. yaw rate.\n",
+    "                    tracking_ang_vel=0.8,\n",
+    "                    # Below are regularization terms, we roughly divide the\n",
+    "                    # terms to base state regularizations, joint\n",
+    "                    # regularizations, and other behavior regularizations.\n",
+    "                    # Penalize the base velocity in z direction, L2 penalty.\n",
+    "                    lin_vel_z=-2.0,\n",
+    "                    # Penalize the base roll and pitch rate. L2 penalty.\n",
+    "                    ang_vel_xy=-0.05,\n",
+    "                    # Penalize non-zero roll and pitch angles. L2 penalty.\n",
+    "                    orientation=-5.0,\n",
+    "                    # L2 regularization of joint torques, |tau|^2.\n",
+    "                    torques=-0.0002,\n",
+    "                    # Penalize the change in the action and encourage smooth\n",
+    "                    # actions. L2 regularization |action - last_action|^2\n",
+    "                    action_rate=-0.01,\n",
+    "                    # Encourage long swing steps.  However, it does not\n",
+    "                    # encourage high clearances.\n",
+    "                    feet_air_time=0.2,\n",
+    "                    # Encourage no motion at zero command, L2 regularization\n",
+    "                    # |q - q_default|^2.\n",
+    "                    stand_still=-0.5,\n",
+    "                    # Early termination penalty.\n",
+    "                    termination=-1.0,\n",
+    "                    # Penalizing foot slipping on the ground.\n",
+    "                    foot_slip=-0.1,\n",
+    "                )\n",
+    "            ),\n",
+    "            # Tracking reward = exp(-error^2/sigma).\n",
+    "            tracking_sigma=0.25,\n",
+    "        )\n",
+    "    )\n",
+    "    return default_config\n",
+    "\n",
+    "  default_config = config_dict.ConfigDict(\n",
+    "      dict(\n",
+    "          rewards=get_default_rewards_config(),\n",
+    "      )\n",
+    "  )\n",
+    "\n",
+    "  return default_config\n",
+    "\n",
+    "\n",
+    "class BarkourEnv(PipelineEnv):\n",
+    "  \"\"\"Environment for training the barkour quadruped joystick policy in MJX.\"\"\"\n",
+    "\n",
+    "  def __init__(\n",
+    "      self,\n",
+    "      obs_noise: float = 0.05,\n",
+    "      action_scale: float = 0.3,\n",
+    "      kick_vel: float = 0.05,\n",
+    "      **kwargs,\n",
+    "  ):\n",
+    "    path = epath.Path('mujoco_menagerie/google_barkour_vb/scene_mjx.xml')\n",
+    "    sys = mjcf.load(path.as_posix())\n",
+    "    self._dt = 0.02  # this environment is 50 fps\n",
+    "    sys = sys.tree_replace({'opt.timestep': 0.004, 'dt': 0.004})\n",
+    "\n",
+    "    # override menagerie params for smoother policy\n",
+    "    sys = sys.replace(\n",
+    "        dof_damping=sys.dof_damping.at[6:].set(0.5239),\n",
+    "        actuator_gainprm=sys.actuator_gainprm.at[:, 0].set(35.0),\n",
+    "        actuator_biasprm=sys.actuator_biasprm.at[:, 1].set(-35.0),\n",
+    "    )\n",
+    "\n",
+    "    n_frames = kwargs.pop('n_frames', int(self._dt / sys.opt.timestep))\n",
+    "    super().__init__(sys, backend='mjx', n_frames=n_frames)\n",
+    "\n",
+    "    self.reward_config = get_config()\n",
+    "    # set custom from kwargs\n",
+    "    for k, v in kwargs.items():\n",
+    "      if k.endswith('_scale'):\n",
+    "        self.reward_config.rewards.scales[k[:-6]] = v\n",
+    "\n",
+    "    self._torso_idx = mujoco.mj_name2id(\n",
+    "        sys.mj_model, mujoco.mjtObj.mjOBJ_BODY.value, 'torso'\n",
+    "    )\n",
+    "    self._action_scale = action_scale\n",
+    "    self._obs_noise = obs_noise\n",
+    "    self._kick_vel = kick_vel\n",
+    "    self._init_q = jp.array(sys.mj_model.keyframe('home').qpos)\n",
+    "    self._default_pose = sys.mj_model.keyframe('home').qpos[7:]\n",
+    "    self.lowers = jp.array([-0.7, -1.0, 0.05] * 4)\n",
+    "    self.uppers = jp.array([0.52, 2.1, 2.1] * 4)\n",
+    "    feet_site = [\n",
+    "        'foot_front_left',\n",
+    "        'foot_hind_left',\n",
+    "        'foot_front_right',\n",
+    "        'foot_hind_right',\n",
+    "    ]\n",
+    "    feet_site_id = [\n",
+    "        mujoco.mj_name2id(sys.mj_model, mujoco.mjtObj.mjOBJ_SITE.value, f)\n",
+    "        for f in feet_site\n",
+    "    ]\n",
+    "    assert not any(id_ == -1 for id_ in feet_site_id), 'Site not found.'\n",
+    "    self._feet_site_id = np.array(feet_site_id)\n",
+    "    lower_leg_body = [\n",
+    "        'lower_leg_front_left',\n",
+    "        'lower_leg_hind_left',\n",
+    "        'lower_leg_front_right',\n",
+    "        'lower_leg_hind_right',\n",
+    "    ]\n",
+    "    lower_leg_body_id = [\n",
+    "        mujoco.mj_name2id(sys.mj_model, mujoco.mjtObj.mjOBJ_BODY.value, l)\n",
+    "        for l in lower_leg_body\n",
+    "    ]\n",
+    "    assert not any(id_ == -1 for id_ in lower_leg_body_id), 'Body not found.'\n",
+    "    self._lower_leg_body_id = np.array(lower_leg_body_id)\n",
+    "    self._foot_radius = 0.0175\n",
+    "    self._nv = sys.nv\n",
+    "\n",
+    "  def sample_command(self, rng: jax.Array) -> jax.Array:\n",
+    "    lin_vel_x = [-0.6, 1.5]  # min max [m/s]\n",
+    "    lin_vel_y = [-0.8, 0.8]  # min max [m/s]\n",
+    "    ang_vel_yaw = [-0.7, 0.7]  # min max [rad/s]\n",
+    "\n",
+    "    _, key1, key2, key3 = jax.random.split(rng, 4)\n",
+    "    lin_vel_x = jax.random.uniform(\n",
+    "        key1, (1,), minval=lin_vel_x[0], maxval=lin_vel_x[1]\n",
+    "    )\n",
+    "    lin_vel_y = jax.random.uniform(\n",
+    "        key2, (1,), minval=lin_vel_y[0], maxval=lin_vel_y[1]\n",
+    "    )\n",
+    "    ang_vel_yaw = jax.random.uniform(\n",
+    "        key3, (1,), minval=ang_vel_yaw[0], maxval=ang_vel_yaw[1]\n",
+    "    )\n",
+    "    new_cmd = jp.array([lin_vel_x[0], lin_vel_y[0], ang_vel_yaw[0]])\n",
+    "    return new_cmd\n",
+    "\n",
+    "  def reset(self, rng: jax.Array) -> State:  # pytype: disable=signature-mismatch\n",
+    "    rng, key = jax.random.split(rng)\n",
+    "\n",
+    "    pipeline_state = self.pipeline_init(self._init_q, jp.zeros(self._nv))\n",
+    "\n",
+    "    state_info = {\n",
+    "        'rng': rng,\n",
+    "        'last_act': jp.zeros(12),\n",
+    "        'last_vel': jp.zeros(12),\n",
+    "        'command': self.sample_command(key),\n",
+    "        'last_contact': jp.zeros(4, dtype=bool),\n",
+    "        'feet_air_time': jp.zeros(4),\n",
+    "        'rewards': {k: 0.0 for k in self.reward_config.rewards.scales.keys()},\n",
+    "        'kick': jp.array([0.0, 0.0]),\n",
+    "        'step': 0,\n",
+    "    }\n",
+    "\n",
+    "    obs_history = jp.zeros(15 * 31)  # store 15 steps of history\n",
+    "    obs = self._get_obs(pipeline_state, state_info, obs_history)\n",
+    "    reward, done = jp.zeros(2)\n",
+    "    metrics = {'total_dist': 0.0}\n",
+    "    for k in state_info['rewards']:\n",
+    "      metrics[k] = state_info['rewards'][k]\n",
+    "    state = State(pipeline_state, obs, reward, done, metrics, state_info)  # pytype: disable=wrong-arg-types\n",
+    "    return state\n",
+    "\n",
+    "  def step(self, state: State, action: jax.Array) -> State:  # pytype: disable=signature-mismatch\n",
+    "    rng, cmd_rng, kick_noise_2 = jax.random.split(state.info['rng'], 3)\n",
+    "\n",
+    "    # kick\n",
+    "    push_interval = 10\n",
+    "    kick_theta = jax.random.uniform(kick_noise_2, maxval=2 * jp.pi)\n",
+    "    kick = jp.array([jp.cos(kick_theta), jp.sin(kick_theta)])\n",
+    "    kick *= jp.mod(state.info['step'], push_interval) == 0\n",
+    "    qvel = state.pipeline_state.qvel  # pytype: disable=attribute-error\n",
+    "    qvel = qvel.at[:2].set(kick * self._kick_vel + qvel[:2])\n",
+    "    state = state.tree_replace({'pipeline_state.qvel': qvel})\n",
+    "\n",
+    "    # physics step\n",
+    "    motor_targets = self._default_pose + action * self._action_scale\n",
+    "    motor_targets = jp.clip(motor_targets, self.lowers, self.uppers)\n",
+    "    pipeline_state = self.pipeline_step(state.pipeline_state, motor_targets)\n",
+    "    x, xd = pipeline_state.x, pipeline_state.xd\n",
+    "\n",
+    "    # observation data\n",
+    "    obs = self._get_obs(pipeline_state, state.info, state.obs)\n",
+    "    joint_angles = pipeline_state.q[7:]\n",
+    "    joint_vel = pipeline_state.qd[6:]\n",
+    "\n",
+    "    # foot contact data based on z-position\n",
+    "    foot_pos = pipeline_state.site_xpos[self._feet_site_id]  # pytype: disable=attribute-error\n",
+    "    foot_contact_z = foot_pos[:, 2] - self._foot_radius\n",
+    "    contact = foot_contact_z < 1e-3  # a mm or less off the floor\n",
+    "    contact_filt_mm = contact | state.info['last_contact']\n",
+    "    contact_filt_cm = (foot_contact_z < 3e-2) | state.info['last_contact']\n",
+    "    first_contact = (state.info['feet_air_time'] > 0) * contact_filt_mm\n",
+    "    state.info['feet_air_time'] += self.dt\n",
+    "\n",
+    "    # done if joint limits are reached or robot is falling\n",
+    "    up = jp.array([0.0, 0.0, 1.0])\n",
+    "    done = jp.dot(math.rotate(up, x.rot[self._torso_idx - 1]), up) < 0\n",
+    "    done |= jp.any(joint_angles < self.lowers)\n",
+    "    done |= jp.any(joint_angles > self.uppers)\n",
+    "    done |= pipeline_state.x.pos[self._torso_idx - 1, 2] < 0.18\n",
+    "\n",
+    "    # reward\n",
+    "    rewards = {\n",
+    "        'tracking_lin_vel': (\n",
+    "            self._reward_tracking_lin_vel(state.info['command'], x, xd)\n",
+    "        ),\n",
+    "        'tracking_ang_vel': (\n",
+    "            self._reward_tracking_ang_vel(state.info['command'], x, xd)\n",
+    "        ),\n",
+    "        'lin_vel_z': self._reward_lin_vel_z(xd),\n",
+    "        'ang_vel_xy': self._reward_ang_vel_xy(xd),\n",
+    "        'orientation': self._reward_orientation(x),\n",
+    "        'torques': self._reward_torques(pipeline_state.qfrc_actuator),  # pytype: disable=attribute-error\n",
+    "        'action_rate': self._reward_action_rate(action, state.info['last_act']),\n",
+    "        'stand_still': self._reward_stand_still(\n",
+    "            state.info['command'], joint_angles,\n",
+    "        ),\n",
+    "        'feet_air_time': self._reward_feet_air_time(\n",
+    "            state.info['feet_air_time'],\n",
+    "            first_contact,\n",
+    "            state.info['command'],\n",
+    "        ),\n",
+    "        'foot_slip': self._reward_foot_slip(pipeline_state, contact_filt_cm),\n",
+    "        'termination': self._reward_termination(done, state.info['step']),\n",
+    "    }\n",
+    "    rewards = {\n",
+    "        k: v * self.reward_config.rewards.scales[k] for k, v in rewards.items()\n",
+    "    }\n",
+    "    reward = jp.clip(sum(rewards.values()) * self.dt, 0.0, 10000.0)\n",
+    "\n",
+    "    # state management\n",
+    "    state.info['kick'] = kick\n",
+    "    state.info['last_act'] = action\n",
+    "    state.info['last_vel'] = joint_vel\n",
+    "    state.info['feet_air_time'] *= ~contact_filt_mm\n",
+    "    state.info['last_contact'] = contact\n",
+    "    state.info['rewards'] = rewards\n",
+    "    state.info['step'] += 1\n",
+    "    state.info['rng'] = rng\n",
+    "\n",
+    "    # sample new command if more than 500 timesteps achieved\n",
+    "    state.info['command'] = jp.where(\n",
+    "        state.info['step'] > 500,\n",
+    "        self.sample_command(cmd_rng),\n",
+    "        state.info['command'],\n",
+    "    )\n",
+    "    # reset the step counter when done\n",
+    "    state.info['step'] = jp.where(\n",
+    "        done | (state.info['step'] > 500), 0, state.info['step']\n",
+    "    )\n",
+    "\n",
+    "    # log total displacement as a proxy metric\n",
+    "    state.metrics['total_dist'] = math.normalize(x.pos[self._torso_idx - 1])[1]\n",
+    "    state.metrics.update(state.info['rewards'])\n",
+    "\n",
+    "    done = jp.float32(done)\n",
+    "    state = state.replace(\n",
+    "        pipeline_state=pipeline_state, obs=obs, reward=reward, done=done\n",
+    "    )\n",
+    "    return state\n",
+    "\n",
+    "  def _get_obs(\n",
+    "      self,\n",
+    "      pipeline_state: base.State,\n",
+    "      state_info: dict[str, Any],\n",
+    "      obs_history: jax.Array,\n",
+    "  ) -> jax.Array:\n",
+    "    inv_torso_rot = math.quat_inv(pipeline_state.x.rot[0])\n",
+    "    local_rpyrate = math.rotate(pipeline_state.xd.ang[0], inv_torso_rot)\n",
+    "\n",
+    "    obs = jp.concatenate([\n",
+    "        jp.array([local_rpyrate[2]]) * 0.25,                 # yaw rate\n",
+    "        math.rotate(jp.array([0, 0, -1]), inv_torso_rot),    # projected gravity\n",
+    "        state_info['command'] * jp.array([2.0, 2.0, 0.25]),  # command\n",
+    "        pipeline_state.q[7:] - self._default_pose,           # motor angles\n",
+    "        state_info['last_act'],                              # last action\n",
+    "    ])\n",
+    "\n",
+    "    # clip, noise\n",
+    "    obs = jp.clip(obs, -100.0, 100.0) + self._obs_noise * jax.random.uniform(\n",
+    "        state_info['rng'], obs.shape, minval=-1, maxval=1\n",
+    "    )\n",
+    "    # stack observations through time\n",
+    "    obs = jp.roll(obs_history, obs.size).at[:obs.size].set(obs)\n",
+    "\n",
+    "    return obs\n",
+    "\n",
+    "  # ------------ reward functions----------------\n",
+    "  def _reward_lin_vel_z(self, xd: Motion) -> jax.Array:\n",
+    "    # Penalize z axis base linear velocity\n",
+    "    return jp.square(xd.vel[0, 2])\n",
+    "\n",
+    "  def _reward_ang_vel_xy(self, xd: Motion) -> jax.Array:\n",
+    "    # Penalize xy axes base angular velocity\n",
+    "    return jp.sum(jp.square(xd.ang[0, :2]))\n",
+    "\n",
+    "  def _reward_orientation(self, x: Transform) -> jax.Array:\n",
+    "    # Penalize non flat base orientation\n",
+    "    up = jp.array([0.0, 0.0, 1.0])\n",
+    "    rot_up = math.rotate(up, x.rot[0])\n",
+    "    return jp.sum(jp.square(rot_up[:2]))\n",
+    "\n",
+    "  def _reward_torques(self, torques: jax.Array) -> jax.Array:\n",
+    "    # Penalize torques\n",
+    "    return jp.sqrt(jp.sum(jp.square(torques))) + jp.sum(jp.abs(torques))\n",
+    "\n",
+    "  def _reward_action_rate(\n",
+    "      self, act: jax.Array, last_act: jax.Array\n",
+    "  ) -> jax.Array:\n",
+    "    # Penalize changes in actions\n",
+    "    return jp.sum(jp.square(act - last_act))\n",
+    "\n",
+    "  def _reward_tracking_lin_vel(\n",
+    "      self, commands: jax.Array, x: Transform, xd: Motion\n",
+    "  ) -> jax.Array:\n",
+    "    # Tracking of linear velocity commands (xy axes)\n",
+    "    local_vel = math.rotate(xd.vel[0], math.quat_inv(x.rot[0]))\n",
+    "    lin_vel_error = jp.sum(jp.square(commands[:2] - local_vel[:2]))\n",
+    "    lin_vel_reward = jp.exp(\n",
+    "        -lin_vel_error / self.reward_config.rewards.tracking_sigma\n",
+    "    )\n",
+    "    return lin_vel_reward\n",
+    "\n",
+    "  def _reward_tracking_ang_vel(\n",
+    "      self, commands: jax.Array, x: Transform, xd: Motion\n",
+    "  ) -> jax.Array:\n",
+    "    # Tracking of angular velocity commands (yaw)\n",
+    "    base_ang_vel = math.rotate(xd.ang[0], math.quat_inv(x.rot[0]))\n",
+    "    ang_vel_error = jp.square(commands[2] - base_ang_vel[2])\n",
+    "    return jp.exp(-ang_vel_error / self.reward_config.rewards.tracking_sigma)\n",
+    "\n",
+    "  def _reward_feet_air_time(\n",
+    "      self, air_time: jax.Array, first_contact: jax.Array, commands: jax.Array\n",
+    "  ) -> jax.Array:\n",
+    "    # Reward air time.\n",
+    "    rew_air_time = jp.sum((air_time - 0.1) * first_contact)\n",
+    "    rew_air_time *= (\n",
+    "        math.normalize(commands[:2])[1] > 0.05\n",
+    "    )  # no reward for zero command\n",
+    "    return rew_air_time\n",
+    "\n",
+    "  def _reward_stand_still(\n",
+    "      self,\n",
+    "      commands: jax.Array,\n",
+    "      joint_angles: jax.Array,\n",
+    "  ) -> jax.Array:\n",
+    "    # Penalize motion at zero commands\n",
+    "    return jp.sum(jp.abs(joint_angles - self._default_pose)) * (\n",
+    "        math.normalize(commands[:2])[1] < 0.1\n",
+    "    )\n",
+    "\n",
+    "  def _reward_foot_slip(\n",
+    "      self, pipeline_state: base.State, contact_filt: jax.Array\n",
+    "  ) -> jax.Array:\n",
+    "    # get velocities at feet which are offset from lower legs\n",
+    "    # pytype: disable=attribute-error\n",
+    "    pos = pipeline_state.site_xpos[self._feet_site_id]  # feet position\n",
+    "    feet_offset = pos - pipeline_state.xpos[self._lower_leg_body_id]\n",
+    "    # pytype: enable=attribute-error\n",
+    "    offset = base.Transform.create(pos=feet_offset)\n",
+    "    foot_indices = self._lower_leg_body_id - 1  # we got rid of the world body\n",
+    "    foot_vel = offset.vmap().do(pipeline_state.xd.take(foot_indices)).vel\n",
+    "\n",
+    "    # Penalize large feet velocity for feet that are in contact with the ground.\n",
+    "    return jp.sum(jp.square(foot_vel[:, :2]) * contact_filt.reshape((-1, 1)))\n",
+    "\n",
+    "  def _reward_termination(self, done: jax.Array, step: jax.Array) -> jax.Array:\n",
+    "    return done & (step < 500)\n",
+    "\n",
+    "  def render(\n",
+    "      self, trajectory: List[base.State], camera: str | None = None\n",
+    "  ) -> Sequence[np.ndarray]:\n",
+    "    camera = camera or 'track'\n",
+    "    return super().render(trajectory, camera=camera)\n",
+    "\n",
+    "envs.register_environment('barkour', BarkourEnv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pi_yrcz-Qp3W"
+   },
+   "outputs": [],
+   "source": [
+    "env_name = 'barkour'\n",
+    "env = envs.get_environment(env_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nxaNFP9mA23H"
+   },
+   "source": [
+    "## Train Policy\n",
+    "\n",
+    "To train a policy with domain randomization, we pass in the domain randomization function into the brax train function; brax will call the domain randomization function when rolling out episodes. Training the quadruped takes 6 minutes on a Tesla A100 GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cHJCbESGA7Rk"
+   },
+   "outputs": [],
+   "source": [
+    "make_networks_factory = functools.partial(\n",
+    "    ppo_networks.make_ppo_networks,\n",
+    "        policy_hidden_layer_sizes=(128, 128, 128, 128))\n",
+    "train_fn = functools.partial(\n",
+    "      ppo.train, num_timesteps=100_000_000, num_evals=10,\n",
+    "      reward_scaling=1, episode_length=1000, normalize_observations=True,\n",
+    "      action_repeat=1, unroll_length=20, num_minibatches=32,\n",
+    "      num_updates_per_batch=4, discounting=0.97, learning_rate=3.0e-4,\n",
+    "      entropy_cost=1e-2, num_envs=8192, batch_size=256,\n",
+    "      network_factory=make_networks_factory,\n",
+    "      randomization_fn=domain_randomize, seed=0)\n",
+    "\n",
+    "x_data = []\n",
+    "y_data = []\n",
+    "ydataerr = []\n",
+    "times = [datetime.now()]\n",
+    "max_y, min_y = 40, 0\n",
+    "\n",
+    "# Reset environments since internals may be overwritten by tracers from the\n",
+    "# domain randomization function.\n",
+    "env = envs.get_environment(env_name)\n",
+    "eval_env = envs.get_environment(env_name)\n",
+    "make_inference_fn, params, _= train_fn(environment=env,\n",
+    "                                       progress_fn=progress,\n",
+    "                                       eval_env=eval_env)\n",
+    "\n",
+    "print(f'time to jit: {times[1] - times[0]}')\n",
+    "print(f'time to train: {times[-1] - times[1]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8Yge-CGP5JoO"
+   },
+   "outputs": [],
+   "source": [
+    "# Save and reload params.\n",
+    "model_path = '/tmp/mjx_brax_quadruped_policy'\n",
+    "model.save_params(model_path, params)\n",
+    "params = model.load_params(model_path)\n",
+    "\n",
+    "inference_fn = make_inference_fn(params)\n",
+    "jit_inference_fn = jax.jit(inference_fn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "L01IrN4oCIkC"
+   },
+   "source": [
+    "## Visualize Policy\n",
+    "\n",
+    "For the Barkour Quadruped, the joystick commands can be set through `x_vel`, `y_vel`, and `ang_vel`. `x_vel` and `y_vel` define the linear forward and sideways velocities with respect to the quadruped torso. `ang_vel` defines the angular velocity of the torso in the z direction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VTbpEtXnEecd"
+   },
+   "outputs": [],
+   "source": [
+    "eval_env = envs.get_environment(env_name)\n",
+    "\n",
+    "jit_reset = jax.jit(eval_env.reset)\n",
+    "jit_step = jax.jit(eval_env.step)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HRRN-8L-BivZ"
+   },
+   "outputs": [],
+   "source": [
+    "# @markdown Commands **only used for Barkour Env**:\n",
+    "x_vel = 1.0  #@param {type: \"number\"}\n",
+    "y_vel = 0.0  #@param {type: \"number\"}\n",
+    "ang_vel = -0.5  #@param {type: \"number\"}\n",
+    "\n",
+    "the_command = jp.array([x_vel, y_vel, ang_vel])\n",
+    "\n",
+    "# initialize the state\n",
+    "rng = jax.random.PRNGKey(0)\n",
+    "state = jit_reset(rng)\n",
+    "state.info['command'] = the_command\n",
+    "rollout = [state.pipeline_state]\n",
+    "\n",
+    "# grab a trajectory\n",
+    "n_steps = 500\n",
+    "render_every = 2\n",
+    "\n",
+    "for i in range(n_steps):\n",
+    "  act_rng, rng = jax.random.split(rng)\n",
+    "  ctrl, _ = jit_inference_fn(state.obs, act_rng)\n",
+    "  state = jit_step(state, ctrl)\n",
+    "  rollout.append(state.pipeline_state)\n",
+    "\n",
+    "media.show_video(\n",
+    "    eval_env.render(rollout[::render_every], camera='track'),\n",
+    "    fps=1.0 / eval_env.dt / render_every)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aD6H6WD0915X"
+   },
+   "source": [
+    "We can also render the rollout using the Brax renderer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "V7jqv08X95u4"
+   },
+   "outputs": [],
+   "source": [
+    "HTML(html.render(eval_env.sys.replace(dt=eval_env.dt), rollout))"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuClass": "premium",
+   "gpuType": "V100",
+   "machine_shape": "hm",
+   "private_outputs": true,
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
* Update pixi.toml to work with pixi 0.16.1
* Update mujoco and mjx to use 3.1.3 version
* Update tutorial.ipynb to be based on the 3.1.3 version, with this local changes:
   * Remove check that google.colab python module is installed
   * Do not try to write a vulkan icd
   * Do not force usage of egl for visualization rendering
* Switch to use jax with cuda 12 builds
   * Since CUDA 12, cuda-nvcc is distributed via conda-forge, so we can avoid using the nvidia channel
   * Apparently for jax to work fine cuda-cupti needs to be installed, so we install it in pixi.toml